### PR TITLE
[LO-20] 링크 메타데이터 도메인 엔티티 개발

### DIFF
--- a/src/main/java/com/meoguri/linkocean/domain/bookmark/entity/Bookmark.java
+++ b/src/main/java/com/meoguri/linkocean/domain/bookmark/entity/Bookmark.java
@@ -1,6 +1,7 @@
 package com.meoguri.linkocean.domain.bookmark.entity;
 
 import static com.meoguri.linkocean.exception.Preconditions.*;
+import static java.time.LocalDateTime.*;
 import static javax.persistence.EnumType.*;
 import static javax.persistence.FetchType.*;
 import static lombok.AccessLevel.*;
@@ -8,7 +9,6 @@ import static lombok.AccessLevel.*;
 import java.time.LocalDateTime;
 
 import javax.persistence.Column;
-import javax.persistence.Embedded;
 import javax.persistence.Entity;
 import javax.persistence.Enumerated;
 import javax.persistence.Lob;
@@ -16,7 +16,6 @@ import javax.persistence.ManyToOne;
 
 import com.meoguri.linkocean.domain.BaseIdEntity;
 import com.meoguri.linkocean.domain.bookmark.entity.vo.OpenType;
-import com.meoguri.linkocean.domain.bookmark.entity.vo.Url;
 import com.meoguri.linkocean.domain.profile.entity.Profile;
 
 import lombok.Builder;
@@ -36,11 +35,11 @@ public class Bookmark extends BaseIdEntity {
 	@ManyToOne(fetch = LAZY)
 	private Profile profile;
 
+	@ManyToOne(fetch = LAZY)
+	private LinkMetadata linkMetadata;
+
 	@Column(nullable = true, length = MAX_BOOKMARK_TITLE_LENGTH)
 	private String title;
-
-	@Embedded
-	private Url url;
 
 	@Column(nullable = true)
 	@Lob
@@ -60,17 +59,17 @@ public class Bookmark extends BaseIdEntity {
 	 * 북마크 등록시 사용하는 생성자
 	 */
 	@Builder
-	private Bookmark(final Profile profile, final String title, final String url, final String memo,
+	private Bookmark(final Profile profile, final LinkMetadata linkMetadata, final String title, final String memo,
 		final OpenType openType) {
 		checkNullableStringLength(title, MAX_BOOKMARK_TITLE_LENGTH, "제목의 길이는 %d보다 작아야 합니다.", MAX_BOOKMARK_TITLE_LENGTH);
 
 		this.profile = profile;
+		this.linkMetadata = linkMetadata;
 		this.title = title;
-		this.url = new Url(url);
 		this.memo = memo;
 		this.openType = openType;
-		this.createdAt = LocalDateTime.now();
-		this.updatedAt = LocalDateTime.now();
+		this.createdAt = now();
+		this.updatedAt = now();
 	}
 
 	/**
@@ -82,7 +81,6 @@ public class Bookmark extends BaseIdEntity {
 		this.title = title;
 		this.memo = memo;
 		this.openType = openType;
-
-		this.updatedAt = LocalDateTime.now();
+		this.updatedAt = now();
 	}
 }

--- a/src/main/java/com/meoguri/linkocean/domain/bookmark/entity/LinkMetadata.java
+++ b/src/main/java/com/meoguri/linkocean/domain/bookmark/entity/LinkMetadata.java
@@ -1,0 +1,35 @@
+package com.meoguri.linkocean.domain.bookmark.entity;
+
+import static lombok.AccessLevel.*;
+
+import javax.persistence.Column;
+import javax.persistence.Embedded;
+import javax.persistence.Entity;
+
+import com.meoguri.linkocean.domain.BaseIdEntity;
+import com.meoguri.linkocean.domain.bookmark.entity.vo.Url;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+@Entity
+public class LinkMetadata extends BaseIdEntity {
+
+	@Embedded
+	private Url url;
+
+	@Column(nullable = false)
+	private String title;
+
+	@Column(nullable = false)
+	private String imageUrl;
+
+	public LinkMetadata(final String link, final String title, final String imageUrl) {
+
+		this.url = new Url(link);
+		this.title = title;
+		this.imageUrl = imageUrl;
+	}
+}

--- a/src/test/java/com/meoguri/linkocean/domain/bookmark/entity/BookmarkTest.java
+++ b/src/test/java/com/meoguri/linkocean/domain/bookmark/entity/BookmarkTest.java
@@ -10,7 +10,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
-import com.meoguri.linkocean.domain.bookmark.entity.vo.Url;
 import com.meoguri.linkocean.domain.profile.entity.Profile;
 
 class BookmarkTest {
@@ -23,13 +22,13 @@ class BookmarkTest {
 	void 북마크_생성_성공(final String memo, final String title) {
 		//given
 		final Profile profile = createProfile();
-		final String textUrl = "https://www.linkocean.com";
+		final LinkMetadata linkMetadata = createLinkMetadata();
 
 		//when
 		final Bookmark bookmark = Bookmark.builder()
 			.profile(profile)
 			.title(title)
-			.url(textUrl)
+			.linkMetadata(linkMetadata)
 			.memo(memo)
 			.openType(ALL)
 			.build();
@@ -39,10 +38,10 @@ class BookmarkTest {
 			.extracting(
 				Bookmark::getProfile,
 				Bookmark::getTitle,
-				Bookmark::getUrl,
+				Bookmark::getLinkMetadata,
 				Bookmark::getMemo,
 				Bookmark::getOpenType
-			).containsExactly(profile, title, new Url(textUrl), memo, ALL);
+			).containsExactly(profile, title, linkMetadata, memo, ALL);
 
 		assertThat(bookmark)
 			.extracting(
@@ -56,7 +55,7 @@ class BookmarkTest {
 		//given
 		final Profile profile = createProfile();
 		final String title = RandomString.make(MAX_PROFILE_USERNAME_LENGTH + 1);
-		final String textUrl = "https://www.linkocean.com";
+		final LinkMetadata linkMetadata = createLinkMetadata();
 		final String memo = "memo";
 
 		//when then
@@ -64,7 +63,7 @@ class BookmarkTest {
 			.isThrownBy(() -> Bookmark.builder()
 				.profile(profile)
 				.title(title)
-				.url(textUrl)
+				.linkMetadata(linkMetadata)
 				.memo(memo)
 				.openType(ALL)
 				.build());

--- a/src/test/java/com/meoguri/linkocean/domain/bookmark/entity/LinkMetadataTest.java
+++ b/src/test/java/com/meoguri/linkocean/domain/bookmark/entity/LinkMetadataTest.java
@@ -1,0 +1,27 @@
+package com.meoguri.linkocean.domain.bookmark.entity;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+import com.meoguri.linkocean.domain.bookmark.entity.vo.Url;
+
+class LinkMetadataTest {
+
+	@Test
+	void 링크_메타데이터_생성_성공() {
+
+		//given
+		final String link = "www.naver.com";
+		final String title = "네이버";
+		final String imageUrl = "naver.png";
+
+		//when
+		final LinkMetadata linkMetadata = new LinkMetadata(link, title, imageUrl);
+
+		//then
+		assertThat(linkMetadata).isNotNull()
+			.extracting(LinkMetadata::getUrl, LinkMetadata::getTitle, LinkMetadata::getImageUrl)
+			.containsExactly(new Url(link), title, imageUrl);
+	}
+}

--- a/src/test/java/com/meoguri/linkocean/domain/util/Fixture.java
+++ b/src/test/java/com/meoguri/linkocean/domain/util/Fixture.java
@@ -3,6 +3,7 @@ package com.meoguri.linkocean.domain.util;
 import static com.meoguri.linkocean.domain.bookmark.entity.vo.OpenType.*;
 
 import com.meoguri.linkocean.domain.bookmark.entity.Bookmark;
+import com.meoguri.linkocean.domain.bookmark.entity.LinkMetadata;
 import com.meoguri.linkocean.domain.bookmark.entity.Tag;
 import com.meoguri.linkocean.domain.profile.entity.Profile;
 import com.meoguri.linkocean.domain.user.entity.User;
@@ -33,10 +34,20 @@ public final class Fixture {
 		return Bookmark.builder()
 			.profile(createProfile())
 			.title("title")
-			.url("www.google.com")
+			.linkMetadata(createLinkMetadata())
 			.memo("dream company")
 			.openType(ALL)
 			.build();
+	}
+
+	public static LinkMetadata createLinkMetadata() {
+
+		return new LinkMetadata(
+
+			"www.google.com",
+			"구글",
+			"google.png"
+		);
 	}
 
 	public static Tag createTag() {


### PR DESCRIPTION
<!-- PR 제목 양식 예시: [LO-N] 회원 기능 도메인 -->

## 🛠️ 작업 내용
- 링크 메타데이터 도메인 엔티티 개발
- 북마크 -> 링크 메타 데이터 1 : N 으로 하였고
- 기존 만들었던 URL vo 를 링크 메타 데이터 엔티티에서 사용하도록 옮겼습니다.
