### PR TITLE
[LO-26] 의존성 테스트 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,12 +64,15 @@ dependencies {
     implementation 'com.google.guava:guava:31.1-jre'
     implementation 'org.jsoup:jsoup:1.14.3'
     implementation 'com.h2database:h2:2.1.212'
+    implementation 'mysql:mysql-connector-java:8.0.29'
+
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
+
     testImplementation('org.springframework.boot:spring-boot-starter-test') {
         exclude group: 'junit' // excluding junit 4
     }
-    implementation 'mysql:mysql-connector-java:8.0.29'
+    testImplementation 'com.tngtech.archunit:archunit:0.23.1'
 }
 
 tasks.named('test') {

--- a/src/test/java/com/meoguri/linkocean/common/DependencyRuleTest.java
+++ b/src/test/java/com/meoguri/linkocean/common/DependencyRuleTest.java
@@ -1,0 +1,57 @@
+package com.meoguri.linkocean.common;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.*;
+import static com.tngtech.archunit.library.Architectures.*;
+
+import org.junit.jupiter.api.Test;
+
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+
+/**
+ * archUnit 을 활용한 의존성 규칙 테스트
+ * <li> 참고 : Naver D2 - <a href="https://d2.naver.com/helloworld/9222129">ArchUnit - UnitTest로 아키텍처 검사</a> </li>
+ */
+class DependencyRuleTest {
+
+	JavaClasses importPackages = new ClassFileImporter().importPackages("com.meoguri.linkocean..");
+
+	/**
+	 * TODO - 컨트롤러 계층 도입 시 코멘트 수정
+	 */
+	@Test
+	void 계층형_아키텍처_의존성_테스트() {
+
+		layeredArchitecture()
+			// .layer("Controller").definedBy("..controller..")
+			.layer("Service").definedBy("..service..")
+			.layer("Persistence").definedBy("..repository..")
+			// .whereLayer("Controller").mayNotBeAccessedByAnyLayer()
+			// .whereLayer("Service").mayOnlyBeAccessedByLayers("Controller")
+			.whereLayer("Service").mayNotBeAccessedByAnyLayer()
+			.whereLayer("Persistence").mayOnlyBeAccessedByLayers("Service")
+			.check(importPackages);
+	}
+
+	@Test
+	void infrastructure_는_domain_에_접근할_수_없다() {
+		String infrastructurePackage = "com.meoguri.linkocean.infrastructure";
+		String domainPackage = "com.meoguri.linkocean.domain";
+
+		denyAnyDependency(infrastructurePackage, domainPackage, importPackages);
+	}
+
+	private void denyAnyDependency(String fromPackage, String toPackage, JavaClasses classes) {
+		noClasses()
+			.that()
+			.resideInAPackage(matchAllClassesInPackage(fromPackage))
+			.should()
+			.dependOnClassesThat()
+			.resideInAnyPackage(matchAllClassesInPackage(toPackage))
+			.check(classes);
+	}
+
+	private String matchAllClassesInPackage(String packageName) {
+		return packageName + "..";
+	}
+}


### PR DESCRIPTION
<!-- PR 제목 양식 예시: [LO-N] 회원 기능 도메인 -->

## 🛠️ 작업 내용
- ArchUnit 추가

## 🗨️ 기타
-  Naver D2 - <a href="https://d2.naver.com/helloworld/9222129">ArchUnit - UnitTest로 아키텍처 검사</a>
- 여기 보고 참고해서 추가하였습니다.
- 컨트롤러 -> 서비스 -> 리포지토리를 꼭 만족해야하며 계층을 건너 뛰지 않고 거꾸로 접근 하지 않는 것을 테스트합니다.
- infrastrucutre 패키지가 domain 에 접근하지 않는 것을 테스트합니다.