### PR TITLE
[LO-27] p6Spy 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ out/
 
 ### Mac OS ###
 .DS_Store
+
+### P6spy long ###
+spy.log

--- a/build.gradle
+++ b/build.gradle
@@ -64,12 +64,15 @@ dependencies {
     implementation 'com.google.guava:guava:31.1-jre'
     implementation 'org.jsoup:jsoup:1.14.3'
     implementation 'com.h2database:h2:2.1.212'
+    implementation 'mysql:mysql-connector-java:8.0.29'
+
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
+
     testImplementation('org.springframework.boot:spring-boot-starter-test') {
         exclude group: 'junit' // excluding junit 4
     }
-    implementation 'mysql:mysql-connector-java:8.0.29'
+    testImplementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.8.0'
 }
 
 tasks.named('test') {

--- a/src/test/java/com/meoguri/linkocean/common/CustomP6spySqlFormat.java
+++ b/src/test/java/com/meoguri/linkocean/common/CustomP6spySqlFormat.java
@@ -1,0 +1,36 @@
+package com.meoguri.linkocean.common;
+
+import java.util.Locale;
+
+import org.hibernate.engine.jdbc.internal.FormatStyle;
+
+import com.p6spy.engine.logging.Category;
+import com.p6spy.engine.spy.appender.MessageFormattingStrategy;
+
+public class CustomP6spySqlFormat implements MessageFormattingStrategy {
+
+	@Override
+	public String formatMessage(int connectionId, String now, long elapsed, String category, String prepared,
+		String sql, String url) {
+		// 한줄 출력 하고 싶으면 아래 return 문 주석 변경
+		// return sql;
+		return formatSql(category, sql);
+	}
+
+	private String formatSql(String category, String sql) {
+		if (sql == null || sql.trim().equals("")) {
+			return sql;
+		}
+
+		// Only format Statement, distinguish DDL And DML
+		if (Category.STATEMENT.getName().equals(category)) {
+			String tmpsql = sql.trim().toLowerCase(Locale.ROOT);
+			if (tmpsql.startsWith("create") || tmpsql.startsWith("alter") || tmpsql.startsWith("comment")) {
+				sql = FormatStyle.DDL.getFormatter().format(sql);
+			} else {
+				sql = FormatStyle.BASIC.getFormatter().format(sql);
+			}
+		}
+		return sql;
+	}
+}

--- a/src/test/java/com/meoguri/linkocean/common/P6spyLogMessageFormatConfiguration.java
+++ b/src/test/java/com/meoguri/linkocean/common/P6spyLogMessageFormatConfiguration.java
@@ -1,0 +1,17 @@
+package com.meoguri.linkocean.common;
+
+import javax.annotation.PostConstruct;
+
+import org.springframework.boot.test.context.TestConfiguration;
+
+import com.p6spy.engine.spy.P6SpyOptions;
+
+@TestConfiguration
+public class P6spyLogMessageFormatConfiguration {
+
+	@PostConstruct
+	public void setLogMessageFormat() {
+		P6SpyOptions.getActiveInstance().setLogMessageFormat(CustomP6spySqlFormat.class.getName());
+	}
+
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -11,7 +11,3 @@ spring:
     generate-ddl: false
     hibernate:
       ddl-auto: create-drop
-    properties:
-      hibernate:
-        format_sql: true
-    show-sql: true


### PR DESCRIPTION
<!-- PR 제목 양식 예시: [LO-N] 회원 기능 도메인 -->

## 🛠️ 작업 내용
- 테스트 코드에서 p6Spy 추가하였습니다.
- 이에 따라 하이버네이트 로그 설정은 지웠습니다. 테스트 로그를 보고 싶은 경우 `@Import(P6spyLogMessageFormatConfiguration.class)` 를 테스트 클래스에 추가해주면 ? placeholder 를 잘 채워준 로그를 볼 수 있습니다.