### PR TITLE
[LO-36] 링크 메타데이터 동기화 기능 리펙토링

### DIFF
--- a/src/main/java/com/meoguri/linkocean/domain/linkmetadata/scheduler/LinkMetadataSynchronizeScheduler.java
+++ b/src/main/java/com/meoguri/linkocean/domain/linkmetadata/scheduler/LinkMetadataSynchronizeScheduler.java
@@ -1,5 +1,9 @@
 package com.meoguri.linkocean.domain.linkmetadata.scheduler;
 
+import static java.util.Objects.*;
+
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
@@ -19,10 +23,15 @@ public class LinkMetadataSynchronizeScheduler {
 	private final LinkMetadataService linkMetadataService;
 
 	/**
-	 *	매주 월요일 0시 0분 0초에 링크 메타 데이터 동기화
+	 *	매주 월요일 0시 0분 0초에 모든 링크 메타 데이터 동기화
 	 */
 	@Scheduled(cron = "0 0 0 * * MON")
 	public void synchronizeAllData() {
-		linkMetadataService.synchronizeAllData(BATCH_SIZE);
+
+		Pageable pageable = PageRequest.of(0, BATCH_SIZE);
+
+		do {
+			pageable = linkMetadataService.synchronizeDataAndReturnNextPageable(pageable);
+		} while (nonNull(pageable));
 	}
 }

--- a/src/main/java/com/meoguri/linkocean/domain/linkmetadata/service/LinkMetadataService.java
+++ b/src/main/java/com/meoguri/linkocean/domain/linkmetadata/service/LinkMetadataService.java
@@ -1,5 +1,7 @@
 package com.meoguri.linkocean.domain.linkmetadata.service;
 
+import org.springframework.data.domain.Pageable;
+
 import com.meoguri.linkocean.domain.linkmetadata.service.dto.PutLinkMetadataResult;
 
 public interface LinkMetadataService {
@@ -16,8 +18,8 @@ public interface LinkMetadataService {
 	PutLinkMetadataResult putLinkMetadataByLink(String link);
 
 	/**
-	 * 모든 링크 메타 데이터를 서비스 정책에 맞춰 주기적으로 업데이트
-	 * (대용량 데이터일 수 있으므로 페이지 단위로 배치 처리)
+	 * 페이지 단위로 링크 메타 데이터를 주기적으로 업데이트 한다.
+	 * @return 다음 페이지, 만약 없으면 null 반환
 	 */
-	void synchronizeAllData(int batchSize);
+	Pageable synchronizeDataAndReturnNextPageable(Pageable pageable);
 }

--- a/src/main/java/com/meoguri/linkocean/domain/linkmetadata/service/LinkMetadataServiceImpl.java
+++ b/src/main/java/com/meoguri/linkocean/domain/linkmetadata/service/LinkMetadataServiceImpl.java
@@ -1,12 +1,7 @@
 package com.meoguri.linkocean.domain.linkmetadata.service;
 
-import static java.util.Objects.*;
-
 import java.util.Optional;
 
-import javax.persistence.EntityManager;
-
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
@@ -32,7 +27,6 @@ public class LinkMetadataServiceImpl implements LinkMetadataService {
 
 	private final LinkMetadataRepository linkMetadataRepository;
 	private final JsoupLinkMetadataService jsoupLinkMetadataService;
-	private final EntityManager entityManager;
 
 	@Override
 	@Transactional(readOnly = true)
@@ -81,26 +75,16 @@ public class LinkMetadataServiceImpl implements LinkMetadataService {
 	}
 
 	@Override
-	public void synchronizeAllData(int batchSize) {
+	public Pageable synchronizeDataAndReturnNextPageable(final Pageable pageable) {
 
-		Pageable pageable = PageRequest.of(0, batchSize);
-
-		// batchSize 단위로 데이터 업데이트
-		do {
-			final Slice<LinkMetadata> slice = linkMetadataRepository.findBy(pageable);
-			slice.getContent()
-				.forEach(linkMetadata -> {
-					final SearchLinkMetadataResult result =
-						jsoupLinkMetadataService.search(addSchemaAndWww(linkMetadata.getUrl().toString()));
-					linkMetadata.update(result.getTitle(), result.getImageUrl());
-				});
-
-			// 페이지 단위로 DB에 업데이트하고 1차 캐쉬 비우기
-			entityManager.flush();
-			entityManager.clear();
-
-			pageable = slice.hasNext() ? slice.nextPageable() : null;
-		} while (nonNull(pageable));
+		final Slice<LinkMetadata> slice = linkMetadataRepository.findBy(pageable);
+		slice.getContent()
+			.forEach(linkMetadata -> {
+				final SearchLinkMetadataResult result =
+					jsoupLinkMetadataService.search(addSchemaAndWww(linkMetadata.getUrl().toString()));
+				linkMetadata.update(result.getTitle(), result.getImageUrl());
+			});
+		return slice.hasNext() ? slice.nextPageable() : null;
 	}
 
 	private String addSchemaAndWww(final String reducedLink) {

--- a/src/main/java/com/meoguri/linkocean/domain/linkmetadata/service/LinkMetadataServiceImpl.java
+++ b/src/main/java/com/meoguri/linkocean/domain/linkmetadata/service/LinkMetadataServiceImpl.java
@@ -81,7 +81,7 @@ public class LinkMetadataServiceImpl implements LinkMetadataService {
 		slice.getContent()
 			.forEach(linkMetadata -> {
 				final SearchLinkMetadataResult result =
-					jsoupLinkMetadataService.search(addSchemaAndWww(linkMetadata.getUrl().toString()));
+					jsoupLinkMetadataService.search(addSchemaAndWww(Url.toString(linkMetadata.getUrl())));
 				linkMetadata.update(result.getTitle(), result.getImageUrl());
 			});
 		return slice.hasNext() ? slice.nextPageable() : null;

--- a/src/test/java/com/meoguri/linkocean/domain/linkmetadata/service/LinkMetadataServiceImplTest.java
+++ b/src/test/java/com/meoguri/linkocean/domain/linkmetadata/service/LinkMetadataServiceImplTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.meoguri.linkocean.domain.linkmetadata.entity.LinkMetadata;
@@ -86,14 +87,14 @@ class LinkMetadataServiceImplTest {
 			.willReturn(new SearchLinkMetadataResult(newTitle, newImageUrl));
 
 		//when
-		linkMetadataService.synchronizeAllData(3);
+		final int batchSize = 3;
+		linkMetadataService.synchronizeDataAndReturnNextPageable(PageRequest.of(0, batchSize));
 
 		//then
-		linkMetadataRepository.findAll()
-			.forEach(linkMetadata ->
-				assertThat(linkMetadata)
-					.extracting(LinkMetadata::getTitle, LinkMetadata::getImageUrl)
-					.containsExactly(newTitle, newImageUrl)
-			);
+		final List<LinkMetadata> linkMetaDatas = linkMetadataRepository.findAll();
+		assertThat(linkMetaDatas)
+			.filteredOn("title", newTitle)
+			.filteredOn("imageUrl", newImageUrl)
+			.hasSize(batchSize);
 	}
 }


### PR DESCRIPTION
## 🛠️ 작업 내용
- 기존 구현은 `LinkMetadataServiceImpl` 에서 `entityManager`에 의존하는 아쉬움이 있었습니다.
- 이를 해결하기위해 스케줄러에서 `while loop` 을 돌아 page 단위로 링크 메타데이터가 업데이트되도록 수정했습니다. 

## 😎 리뷰어
@jk05018 @ndy2 