### PR TITLE
[LO-72] contextLoad 테스트는 local 프로파일에서 수행하도록 수정

### DIFF
--- a/.github/workflows/test-every-pull-request.yml
+++ b/.github/workflows/test-every-pull-request.yml
@@ -27,6 +27,10 @@ jobs:
           java-version: '11'
           distribution: 'temurin'
 
+      ## set mysql docker container
+      - name: build docker-compose
+        run: docker-compose up -d
+
       ## gradle caching
       - name: Gradle Caching
         uses: actions/cache@v3

--- a/src/test/java/com/meoguri/linkocean/LinkoceanApplicationTests.java
+++ b/src/test/java/com/meoguri/linkocean/LinkoceanApplicationTests.java
@@ -2,8 +2,10 @@ package com.meoguri.linkocean;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("local")
 class LinkoceanApplicationTests {
 
 	@Test


### PR DESCRIPTION
## 🛠️ 작업 내용
- `contextLoad` 테스트는 `local` 프로파일에서 수행하도록 수정

## 🗨️ 기타
- `github actions`에서도 `flyway` `migration`이 잘 되었는지 테스트 할 수 있습니다! 

## 😎 리뷰어
@ndy2 , @jk05018
