### PR TITLE
[LO-81] 태그 목록 조회 초벌

### DIFF
--- a/src/main/java/com/meoguri/linkocean/domain/bookmark/entity/Bookmark.java
+++ b/src/main/java/com/meoguri/linkocean/domain/bookmark/entity/Bookmark.java
@@ -3,6 +3,7 @@ package com.meoguri.linkocean.domain.bookmark.entity;
 import static com.meoguri.linkocean.exception.Preconditions.*;
 import static java.time.LocalDateTime.*;
 import static java.util.stream.Collectors.*;
+import static javax.persistence.CascadeType.*;
 import static javax.persistence.EnumType.*;
 import static javax.persistence.FetchType.*;
 import static lombok.AccessLevel.*;
@@ -12,7 +13,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Enumerated;
@@ -45,7 +45,7 @@ public class Bookmark extends BaseIdEntity {
 	private LinkMetadata linkMetadata;
 
 	/* BookmarkTag의 생명주기는 Bookmark 엔티티가 관리 */
-	@OneToMany(mappedBy = "bookmark", cascade = CascadeType.ALL, orphanRemoval = true)
+	@OneToMany(mappedBy = "bookmark", cascade = PERSIST, orphanRemoval = true)
 	private List<BookmarkTag> bookmarkTags = new ArrayList<>();
 
 	@Column(nullable = true, length = MAX_BOOKMARK_TITLE_LENGTH)
@@ -92,6 +92,10 @@ public class Bookmark extends BaseIdEntity {
 	 */
 	public void addBookmarkTag(Tag tag) {
 		this.bookmarkTags.add(new BookmarkTag(this, tag));
+	}
+
+	public List<String> getTagNames() {
+		return bookmarkTags.stream().map(BookmarkTag::getTagName).collect(toList());
 	}
 
 	public String getCategory() {

--- a/src/main/java/com/meoguri/linkocean/domain/bookmark/entity/BookmarkTag.java
+++ b/src/main/java/com/meoguri/linkocean/domain/bookmark/entity/BookmarkTag.java
@@ -27,4 +27,8 @@ public class BookmarkTag extends BaseIdEntity {
 		this.bookmark = bookmark;
 		this.tag = tag;
 	}
+
+	public String getTagName() {
+		return tag.getName();
+	}
 }

--- a/src/main/java/com/meoguri/linkocean/domain/bookmark/persistence/BookmarkRepository.java
+++ b/src/main/java/com/meoguri/linkocean/domain/bookmark/persistence/BookmarkRepository.java
@@ -14,6 +14,10 @@ public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
 
 	Optional<Bookmark> findByProfileAndLinkMetadata(Profile profile, LinkMetadata linkMetadata);
 
-	@Query("select distinct b from Bookmark b join fetch b.bookmarkTags bt join fetch bt.tag where b.profile = :profile")
+	@Query("select distinct b "
+		+ "from Bookmark b "
+		+ "join fetch b.bookmarkTags bt "
+		+ "join fetch bt.tag "
+		+ "where b.profile = :profile")
 	List<Bookmark> findByProfileFetchTags(Profile profile);
 }

--- a/src/main/java/com/meoguri/linkocean/domain/bookmark/persistence/BookmarkRepository.java
+++ b/src/main/java/com/meoguri/linkocean/domain/bookmark/persistence/BookmarkRepository.java
@@ -1,8 +1,10 @@
 package com.meoguri.linkocean.domain.bookmark.persistence;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import com.meoguri.linkocean.domain.bookmark.entity.Bookmark;
 import com.meoguri.linkocean.domain.linkmetadata.entity.LinkMetadata;
@@ -11,4 +13,7 @@ import com.meoguri.linkocean.domain.profile.entity.Profile;
 public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
 
 	Optional<Bookmark> findByProfileAndLinkMetadata(Profile profile, LinkMetadata linkMetadata);
+
+	@Query("select distinct b from Bookmark b join fetch b.bookmarkTags bt join fetch bt.tag where b.profile = :profile")
+	List<Bookmark> findByProfileFetchTags(Profile profile);
 }

--- a/src/main/java/com/meoguri/linkocean/domain/bookmark/service/TagService.java
+++ b/src/main/java/com/meoguri/linkocean/domain/bookmark/service/TagService.java
@@ -1,0 +1,10 @@
+package com.meoguri.linkocean.domain.bookmark.service;
+
+import java.util.List;
+
+import com.meoguri.linkocean.domain.bookmark.service.dto.GetMyTagsResult;
+
+public interface TagService {
+
+	List<GetMyTagsResult> getMyTags(long userId);
+}

--- a/src/main/java/com/meoguri/linkocean/domain/bookmark/service/TagServiceImpl.java
+++ b/src/main/java/com/meoguri/linkocean/domain/bookmark/service/TagServiceImpl.java
@@ -1,0 +1,35 @@
+package com.meoguri.linkocean.domain.bookmark.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.meoguri.linkocean.domain.bookmark.entity.Bookmark;
+import com.meoguri.linkocean.domain.bookmark.persistence.BookmarkRepository;
+import com.meoguri.linkocean.domain.bookmark.persistence.TagRepository;
+import com.meoguri.linkocean.domain.bookmark.service.dto.GetMyTagsResult;
+import com.meoguri.linkocean.domain.profile.entity.Profile;
+import com.meoguri.linkocean.domain.profile.persistence.FindProfileByUserIdQuery;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Transactional
+@Service
+public class TagServiceImpl implements TagService {
+
+	private final TagRepository tagRepository;
+	private final FindProfileByUserIdQuery findProfileByUserIdQuery;
+	private final BookmarkRepository bookmarkRepository;
+
+	@Override
+	public List<GetMyTagsResult> getMyTags(final long userId) {
+
+		final Profile profile = findProfileByUserIdQuery.findByUserId(userId);
+		final List<Bookmark> bookmarks = bookmarkRepository.findByProfileFetchTags(profile);
+
+		//TODO - 메모리에서 Result 말아주는 로직 짜기
+		return null;
+	}
+}

--- a/src/main/java/com/meoguri/linkocean/domain/bookmark/service/dto/GetMyTagsResult.java
+++ b/src/main/java/com/meoguri/linkocean/domain/bookmark/service/dto/GetMyTagsResult.java
@@ -1,0 +1,12 @@
+package com.meoguri.linkocean.domain.bookmark.service.dto;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class GetMyTagsResult {
+
+	private final String tag;
+	private final int count;
+}

--- a/src/test/java/com/meoguri/linkocean/domain/bookmark/persistence/BookmarkRepositoryTest.java
+++ b/src/test/java/com/meoguri/linkocean/domain/bookmark/persistence/BookmarkRepositoryTest.java
@@ -3,22 +3,39 @@ package com.meoguri.linkocean.domain.bookmark.persistence;
 import static com.meoguri.linkocean.domain.util.Fixture.*;
 import static org.assertj.core.api.Assertions.*;
 
+import java.util.List;
 import java.util.Optional;
 
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.test.context.TestPropertySource;
 
 import com.meoguri.linkocean.common.CustomP6spySqlFormat;
 import com.meoguri.linkocean.domain.bookmark.entity.Bookmark;
+import com.meoguri.linkocean.domain.bookmark.entity.Tag;
+import com.meoguri.linkocean.domain.linkmetadata.entity.LinkMetadata;
 import com.meoguri.linkocean.domain.linkmetadata.persistence.LinkMetadataRepository;
+import com.meoguri.linkocean.domain.profile.entity.Profile;
 import com.meoguri.linkocean.domain.profile.persistence.ProfileRepository;
+import com.meoguri.linkocean.domain.user.entity.User;
 import com.meoguri.linkocean.domain.user.repository.UserRepository;
 
+@TestPropertySource(properties = {
+	"logging.level.org.hibernate.SQL=DEBUG",
+	"logging.level.org.hibernate.type.descriptor.sql.BasicBinder=TRACE"
+})
 @Import(CustomP6spySqlFormat.class)
 @DataJpaTest
 class BookmarkRepositoryTest {
+
+	@PersistenceContext
+	private EntityManager em;
 
 	@Autowired
 	private BookmarkRepository bookmarkRepository;
@@ -32,23 +49,77 @@ class BookmarkRepositoryTest {
 	@Autowired
 	private UserRepository userRepository;
 
+	@Autowired
+	private TagRepository tagRepository;
+
+	private Profile profile;
+	private LinkMetadata link;
+	private Tag tag1, tag2, tag3;
+
+	@BeforeEach
+	void setUp() {
+		// 프로필, 링크 셋업
+		User user = userRepository.save(createUser());
+		profile = profileRepository.save(createProfile(user));
+		link = linkMetadataRepository.save(createLinkMetadata());
+
+		// 태그 셋업
+		tag1 = tagRepository.save(new Tag("tag1"));
+		tag2 = tagRepository.save(new Tag("tag2"));
+		tag3 = tagRepository.save(new Tag("tag3"));
+	}
+
 	@Test
 	void 프로필_url_이용한_북마크_조회() {
 		//given
-		final Bookmark bookmark = createBookmark();
-
-		userRepository.save(bookmark.getProfile().getUser());
-		profileRepository.save(bookmark.getProfile());
-		linkMetadataRepository.save(bookmark.getLinkMetadata());
-
+		final Bookmark bookmark = createBookmark(profile, link);
 		bookmarkRepository.save(bookmark);
 
 		//when
-		final Optional<Bookmark> retrievedBookmark = bookmarkRepository.findByProfileAndLinkMetadata(
-			bookmark.getProfile(),
-			bookmark.getLinkMetadata());
+		final Optional<Bookmark> oBookmark =
+			bookmarkRepository.findByProfileAndLinkMetadata(bookmark.getProfile(), bookmark.getLinkMetadata());
 
 		//then
-		assertThat(retrievedBookmark).isNotNull();
+		assertThat(oBookmark).isPresent();
 	}
+
+	@Test
+	void 사용자의_전체_북마크조회_태그_까지_페치_성공() {
+		//given
+		final Bookmark bookmark1 = createBookmark(profile, link, "bookmark1");
+		final Bookmark bookmark2 = createBookmark(profile, link, "bookmark2");
+		final Bookmark bookmark3 = createBookmark(profile, link, "bookmark3");
+
+		bookmark1.addBookmarkTag(tag1);
+		bookmark1.addBookmarkTag(tag2);
+		bookmark1.addBookmarkTag(tag3);
+
+		bookmark2.addBookmarkTag(tag2);
+		bookmark2.addBookmarkTag(tag3);
+
+		bookmark3.addBookmarkTag(tag3);
+
+		bookmarkRepository.save(bookmark1);
+		bookmarkRepository.save(bookmark2);
+		bookmarkRepository.save(bookmark3);
+
+		em.flush();
+		em.clear();
+
+		//when
+		final List<Bookmark> bookmarks = bookmarkRepository.findByProfileFetchTags(profile);
+
+		em.flush();
+		em.clear();
+
+		//then
+		assertThat(bookmarks).hasSize(3)
+			.extracting(Bookmark::getTitle, Bookmark::getTagNames)
+			.containsExactly(
+				tuple("bookmark1", List.of("tag1", "tag2", "tag3")),
+				tuple("bookmark2", List.of("tag2", "tag3")),
+				tuple("bookmark3", List.of("tag3"))
+			);
+	}
+
 }

--- a/src/test/java/com/meoguri/linkocean/domain/bookmark/persistence/BookmarkRepositoryTest.java
+++ b/src/test/java/com/meoguri/linkocean/domain/bookmark/persistence/BookmarkRepositoryTest.java
@@ -54,7 +54,9 @@ class BookmarkRepositoryTest {
 
 	private Profile profile;
 	private LinkMetadata link;
-	private Tag tag1, tag2, tag3;
+	private Tag tag1;
+	private Tag tag2;
+	private Tag tag3;
 
 	@BeforeEach
 	void setUp() {

--- a/src/test/java/com/meoguri/linkocean/domain/util/Fixture.java
+++ b/src/test/java/com/meoguri/linkocean/domain/util/Fixture.java
@@ -28,10 +28,20 @@ public final class Fixture {
 
 	public static Bookmark createBookmark() {
 
+		return createBookmark(createProfile(), createLinkMetadata());
+	}
+
+	public static Bookmark createBookmark(Profile profile, LinkMetadata linkMetadata) {
+
+		return createBookmark(profile, linkMetadata, "title");
+	}
+
+	public static Bookmark createBookmark(Profile profile, LinkMetadata linkMetadata, String title) {
+
 		return Bookmark.builder()
-			.profile(createProfile())
-			.title("title")
-			.linkMetadata(createLinkMetadata())
+			.profile(profile)
+			.title(title)
+			.linkMetadata(linkMetadata)
 			.memo("dream company")
 			.category("it")
 			.openType("all")


### PR DESCRIPTION
## 🛠️ 작업 내용
- 태그 목록 조회 초벌
- 북마크를 전부 끌어와서 애플리케이션 로직에서 태그기준으로 나열 후 카운트를 세 주는것이 나을거 같아 그 방법으로 구현하려고 합니다.

- 영속성 계층 구현하였고 서비스 계층은 아직입니다.