### PR TITLE
[LO-53] security 설정 및 이슈 해결, 앞으로 ControllerTest에선 @WithMockUser를!

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -86,6 +86,7 @@ dependencies {
         exclude group: 'junit' // excluding junit 4
     }
 
+    testImplementation 'org.springframework.security:spring-security-test'
     testImplementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.8.0'
     testImplementation 'com.tngtech.archunit:archunit:0.23.1'
 }

--- a/src/main/java/com/meoguri/linkocean/configuration/security/SecurityConfiguration.java
+++ b/src/main/java/com/meoguri/linkocean/configuration/security/SecurityConfiguration.java
@@ -5,6 +5,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.web.SecurityFilterChain;
 
+import com.meoguri.linkocean.configuration.security.oauth.CustomAuthenticationEntryPoint;
 import com.meoguri.linkocean.configuration.security.oauth.CustomOAuth2UserService;
 
 import lombok.RequiredArgsConstructor;
@@ -14,6 +15,7 @@ import lombok.RequiredArgsConstructor;
 public class SecurityConfiguration {
 
 	private final CustomOAuth2UserService customOAuth2UserService;
+	private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
 
 	@Bean
 	public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -21,11 +23,15 @@ public class SecurityConfiguration {
 			.csrf().disable()
 			.headers().frameOptions().disable()
 			.and()
+			.formLogin().disable()
 			.authorizeRequests()
-			.anyRequest().permitAll()
+			.anyRequest().hasRole("USER")
 			.and()
 			.logout()
 			.logoutSuccessUrl("/")
+			.and()
+			.exceptionHandling()
+			.authenticationEntryPoint(customAuthenticationEntryPoint)
 			.and()
 			.oauth2Login(oauth2 ->
 				oauth2.userInfoEndpoint().userService(customOAuth2UserService)

--- a/src/main/java/com/meoguri/linkocean/configuration/security/oauth/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/meoguri/linkocean/configuration/security/oauth/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,43 @@
+package com.meoguri.linkocean.configuration.security.oauth;
+
+import static org.springframework.http.HttpStatus.*;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Component
+@Slf4j
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+	@Override
+	public void commence(final HttpServletRequest request, final HttpServletResponse response,
+		final AuthenticationException ex) throws IOException, ServletException {
+		log.debug(ex.getMessage(), ex);
+
+		response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+		response.setStatus(BAD_REQUEST.value());
+
+		try (OutputStream os = response.getOutputStream()) {
+			final ObjectMapper objectMapper = new ObjectMapper();
+			final ObjectNode errorResponse = objectMapper.createObjectNode()
+				.put("code", BAD_REQUEST.value())
+				.put("message", "페이지에 접근할 권한이 없습니다.");
+			objectMapper.writeValue(os, errorResponse);
+			os.flush();
+		}
+	}
+}

--- a/src/main/java/com/meoguri/linkocean/configuration/security/oauth/CustomOAuth2UserService.java
+++ b/src/main/java/com/meoguri/linkocean/configuration/security/oauth/CustomOAuth2UserService.java
@@ -4,6 +4,7 @@ import java.util.Collections;
 
 import javax.servlet.http.HttpSession;
 
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
@@ -53,7 +54,7 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
 		httpSession.setAttribute("user", new SessionUser(user));
 
 		return new DefaultOAuth2User(
-			Collections.emptySet(),
+			Collections.singleton(new SimpleGrantedAuthority("ROLE_USER")),
 			attributes.getAttributes(),
 			"email"
 		);

--- a/src/main/java/com/meoguri/linkocean/configuration/security/oauth/SessionUser.java
+++ b/src/main/java/com/meoguri/linkocean/configuration/security/oauth/SessionUser.java
@@ -1,5 +1,7 @@
 package com.meoguri.linkocean.configuration.security.oauth;
 
+import java.io.Serializable;
+
 import com.meoguri.linkocean.domain.user.entity.User;
 
 import lombok.Getter;
@@ -9,7 +11,7 @@ import lombok.Getter;
  * - 일단 최소한의 정보인 id 만 포함
  */
 @Getter
-public class SessionUser {
+public class SessionUser implements Serializable {
 
 	private final long id;
 

--- a/src/main/java/com/meoguri/linkocean/controller/CustomRestControllerAdvice.java
+++ b/src/main/java/com/meoguri/linkocean/controller/CustomRestControllerAdvice.java
@@ -2,12 +2,9 @@ package com.meoguri.linkocean.controller;
 
 import static org.springframework.http.HttpStatus.*;
 
-import java.nio.file.AccessDeniedException;
-
 import org.hibernate.TypeMismatchException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.converter.HttpMessageNotReadableException;
-import org.springframework.security.core.AuthenticationException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -30,14 +27,6 @@ public class CustomRestControllerAdvice {
 		return ErrorResponse.of(BAD_REQUEST, ex.getMessage());
 	}
 
-	@ResponseStatus(UNAUTHORIZED)
-	@ExceptionHandler({AuthenticationException.class, AccessDeniedException.class})
-	public ErrorResponse handleAuthroizationException(RuntimeException ex) {
-		log.debug(ex.getMessage(), ex);
-
-		return ErrorResponse.of(BAD_REQUEST, "페이지에 접근할 권한이 없습니다.");
-	}
-
 	@ResponseStatus(BAD_REQUEST)
 	@ExceptionHandler({LinkoceanRuntimeException.class,
 		TypeMismatchException.class, HttpMessageNotReadableException.class,
@@ -58,12 +47,12 @@ public class CustomRestControllerAdvice {
 
 	@Getter
 	@AllArgsConstructor
-	private static class ErrorResponse {
+	public static class ErrorResponse {
 
 		private int code;
 		private String message;
 
-		static ErrorResponse of(HttpStatus status, String message) {
+		public static ErrorResponse of(HttpStatus status, String message) {
 			return new ErrorResponse(status.value(), message);
 		}
 	}

--- a/src/test/java/com/meoguri/linkocean/controller/category/CategoryControllerTest.java
+++ b/src/test/java/com/meoguri/linkocean/controller/category/CategoryControllerTest.java
@@ -7,6 +7,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
 
 import com.meoguri.linkocean.controller.BaseControllerTest;
 import com.meoguri.linkocean.domain.bookmark.entity.Bookmark.Category;
@@ -15,6 +16,7 @@ class CategoryControllerTest extends BaseControllerTest {
 
 	private final String basePath = getBaseUrl(CategoryController.class);
 
+	@WithMockUser(roles = "USER")
 	@Test
 	void 카테고리_전체_조회_Api_성공() throws Exception {
 		//when

--- a/src/test/java/com/meoguri/linkocean/controller/user/LoginControllerTest.java
+++ b/src/test/java/com/meoguri/linkocean/controller/user/LoginControllerTest.java
@@ -2,7 +2,7 @@ package com.meoguri.linkocean.controller.user;
 
 import com.meoguri.linkocean.controller.BaseControllerTest;
 
-//TODO - 로그인 통합 테스트 구현
+//TODO - 로그인 통합 테스트 구현 -> 프로필 API를 만든 다음 작성하겠습니다 - by hani
 class LoginControllerTest extends BaseControllerTest {
 
 }


### PR DESCRIPTION
<!-- PR 제목 양식 예시: [LO-N] 회원 기능 도메인 -->

## 🛠️ 작업 내용
- security-config 설정 변경
- 권한 없는 사용자를 controllerAdvice가 잡지 못하는 이슈 발생
- @WithMockUser 어노테이션 추가 

자세한 내용은 해당 커밋에 잘 남겨 두었습니다.

## 🗨️ 기타
- 원래 authenticationENtiryPoint에서 잘 살펴보시면 ObjectMapper.createNode() 를 통해 json을 만들어 내고 있는 것을 보실 수 있습니다. 처음에는 CUstomControllerAdvice.ErrorResponse를 참조하려다가 dependencyTest에서 걸리더군요!
혹시나 이거 ErrorResponse를 참조하면 되지 않을까 궁금하신 분들이 있으실 것 같아서!

## 😎 리뷰어
@NewEgoDoc, @hyuk0309

