### PR TITLE
[LO-52] 내정보 조회(사용자 태그목록, 카테고리 목록 추가) 외 다양한 작업들

### DIFF
--- a/src/main/java/com/meoguri/linkocean/configuration/WebConfiguration.java
+++ b/src/main/java/com/meoguri/linkocean/configuration/WebConfiguration.java
@@ -2,7 +2,11 @@ package com.meoguri.linkocean.configuration;
 
 import java.util.List;
 
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
@@ -19,5 +23,19 @@ public class WebConfiguration implements WebMvcConfigurer {
 	@Override
 	public void addArgumentResolvers(final List<HandlerMethodArgumentResolver> resolvers) {
 		resolvers.add(loginUserArgumentResolver);
+	}
+
+	@Bean
+	public CorsConfigurationSource corsConfigurationSource() {
+		CorsConfiguration configuration = new CorsConfiguration();
+		// - (3)
+		configuration.addAllowedOrigin("*");
+		configuration.addAllowedMethod("*");
+		configuration.addAllowedHeader("*");
+		configuration.setAllowCredentials(true);
+		configuration.setMaxAge(3600L);
+		UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+		source.registerCorsConfiguration("/**", configuration);
+		return source;
 	}
 }

--- a/src/main/java/com/meoguri/linkocean/controller/bookmark/dto/RegisterBookmarkRequest.java
+++ b/src/main/java/com/meoguri/linkocean/controller/bookmark/dto/RegisterBookmarkRequest.java
@@ -4,9 +4,11 @@ import java.util.List;
 
 import com.meoguri.linkocean.domain.bookmark.service.dto.RegisterBookmarkCommand;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
+@AllArgsConstructor
 public final class RegisterBookmarkRequest {
 
 	private String url;

--- a/src/main/java/com/meoguri/linkocean/controller/linkmetadata/LinkMetadataController.java
+++ b/src/main/java/com/meoguri/linkocean/controller/linkmetadata/LinkMetadataController.java
@@ -1,6 +1,6 @@
 package com.meoguri.linkocean.controller.linkmetadata;
 
-import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -17,7 +17,7 @@ public class LinkMetadataController {
 
 	private final LinkMetadataService linkMetadataService;
 
-	@GetMapping
+	@PostMapping("/obtain")
 	public LinkMetadataTitleResponse getLinkMetaTitle(@RequestParam("link") String link) {
 		return LinkMetadataTitleResponse.of(linkMetadataService.getTitleByLink(link));
 	}

--- a/src/main/java/com/meoguri/linkocean/controller/linkmetadata/LinkMetadataController.java
+++ b/src/main/java/com/meoguri/linkocean/controller/linkmetadata/LinkMetadataController.java
@@ -1,0 +1,24 @@
+package com.meoguri.linkocean.controller.linkmetadata;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.meoguri.linkocean.controller.linkmetadata.dto.LinkMetadataTitleResponse;
+import com.meoguri.linkocean.domain.linkmetadata.service.LinkMetadataService;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/linkmetadatas")
+@RestController
+public class LinkMetadataController {
+
+	private final LinkMetadataService linkMetadataService;
+
+	@GetMapping
+	public LinkMetadataTitleResponse getLinkMetaTitle(@RequestParam("link") String link) {
+		return LinkMetadataTitleResponse.of(linkMetadataService.getTitleByLink(link));
+	}
+}

--- a/src/main/java/com/meoguri/linkocean/controller/linkmetadata/dto/LinkMetadataTitleResponse.java
+++ b/src/main/java/com/meoguri/linkocean/controller/linkmetadata/dto/LinkMetadataTitleResponse.java
@@ -1,0 +1,16 @@
+package com.meoguri.linkocean.controller.linkmetadata.dto;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class LinkMetadataTitleResponse {
+
+	private final String title;
+
+	public static LinkMetadataTitleResponse of(final String title) {
+		return new LinkMetadataTitleResponse(title);
+	}
+
+}

--- a/src/main/java/com/meoguri/linkocean/controller/profile/ProfileController.java
+++ b/src/main/java/com/meoguri/linkocean/controller/profile/ProfileController.java
@@ -1,5 +1,6 @@
 package com.meoguri.linkocean.controller.profile;
 
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -8,6 +9,9 @@ import org.springframework.web.bind.annotation.RestController;
 import com.meoguri.linkocean.configuration.security.oauth.LoginUser;
 import com.meoguri.linkocean.configuration.security.oauth.SessionUser;
 import com.meoguri.linkocean.controller.profile.dto.CreateProfileRequest;
+import com.meoguri.linkocean.controller.profile.dto.GetMyProfileResponse;
+import com.meoguri.linkocean.domain.bookmark.service.CategoryService;
+import com.meoguri.linkocean.domain.bookmark.service.TagService;
 import com.meoguri.linkocean.domain.profile.service.ProfileService;
 
 import lombok.RequiredArgsConstructor;
@@ -18,6 +22,8 @@ import lombok.RequiredArgsConstructor;
 public class ProfileController {
 
 	private final ProfileService profileService;
+	private final CategoryService categoryService;
+	private final TagService tagService;
 
 	@PostMapping
 	public void createProfile(
@@ -25,5 +31,16 @@ public class ProfileController {
 		@RequestBody CreateProfileRequest request
 	) {
 		profileService.registerProfile(request.toCommand(user.getId()));
+	}
+
+	@GetMapping("/me")
+	public GetMyProfileResponse getMyProfile(
+		@LoginUser SessionUser user
+	) {
+		return GetMyProfileResponse.of(
+			profileService.getMyProfile(user.getId()),
+			tagService.getMyTags(user.getId()),
+			categoryService.getUsedCategories(user.getId())
+		);
 	}
 }

--- a/src/main/java/com/meoguri/linkocean/controller/profile/dto/GetMyProfileResponse.java
+++ b/src/main/java/com/meoguri/linkocean/controller/profile/dto/GetMyProfileResponse.java
@@ -1,0 +1,42 @@
+package com.meoguri.linkocean.controller.profile.dto;
+
+import java.util.List;
+
+import com.meoguri.linkocean.domain.bookmark.service.dto.GetMyTagsResult;
+import com.meoguri.linkocean.domain.profile.service.dto.GetMyProfileResult;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class GetMyProfileResponse {
+
+	private final Long profileId;
+	private final String imageUrl;
+	private final List<String> favoriteCategories;
+	private final String username;
+	private final String bio;
+	private final int followerCount;
+	private final int followeeCount;
+	private final List<GetMyTagsResult> tags;
+	private final List<String> categories;
+
+	public static GetMyProfileResponse of(
+		final GetMyProfileResult result,
+		final List<GetMyTagsResult> tags,
+		final List<String> categories) {
+		return new GetMyProfileResponse(
+			result.getProfileId(),
+			result.getImageUrl(),
+			result.getFavoriteCategories(),
+			result.getUsername(),
+			result.getBio(),
+			result.getFollowerCount(),
+			result.getFolloweeCount(),
+			tags,
+			categories
+		);
+	}
+
+}

--- a/src/main/java/com/meoguri/linkocean/domain/bookmark/entity/Bookmark.java
+++ b/src/main/java/com/meoguri/linkocean/domain/bookmark/entity/Bookmark.java
@@ -126,7 +126,7 @@ public class Bookmark extends BaseIdEntity {
 	}
 
 	public String getCategory() {
-		return category.getName();
+		return category.getKorName();
 	}
 
 	public String getOpenType() {
@@ -175,19 +175,19 @@ public class Bookmark extends BaseIdEntity {
 		TRAVEL("여행"),
 		COOKING("요리");
 
-		private final String name;
+		private final String korName;
 
 		public static List<String> getEnglishNames() {
-			return Arrays.stream(Category.values()).map(v -> v.name).collect(toList());
+			return Arrays.stream(Category.values()).map(v -> v.korName).collect(toList());
 		}
 
 		public static List<String> getKoreanNames() {
-			return Arrays.stream(Category.values()).map(Category::getName).collect(toList());
+			return Arrays.stream(Category.values()).map(Category::getKorName).collect(toList());
 		}
 
 		public static Category of(String arg) {
 			return arg == null ? null : Arrays.stream(Category.values())
-				.filter(category -> category.name.equals(arg))
+				.filter(category -> category.korName.equals(arg))
 				.findAny()
 				.orElseThrow(() -> new LinkoceanRuntimeException());
 		}

--- a/src/main/java/com/meoguri/linkocean/domain/bookmark/entity/Bookmark.java
+++ b/src/main/java/com/meoguri/linkocean/domain/bookmark/entity/Bookmark.java
@@ -184,12 +184,11 @@ public class Bookmark extends BaseIdEntity {
 			return Arrays.stream(Category.values()).map(Category::getName).collect(toList());
 		}
 
-		public String getName() {
-			return name().toLowerCase();
-		}
-
 		public static Category of(String arg) {
-			return arg == null ? null : Category.valueOf(arg.toUpperCase());
+			return Arrays.stream(Category.values())
+				.filter(category -> category.name.equals(arg))
+				.findAny()
+				.orElseThrow(() -> new IllegalStateException());
 		}
 	}
 }

--- a/src/main/java/com/meoguri/linkocean/domain/bookmark/entity/Bookmark.java
+++ b/src/main/java/com/meoguri/linkocean/domain/bookmark/entity/Bookmark.java
@@ -23,6 +23,7 @@ import javax.persistence.OneToMany;
 import com.meoguri.linkocean.domain.BaseIdEntity;
 import com.meoguri.linkocean.domain.linkmetadata.entity.LinkMetadata;
 import com.meoguri.linkocean.domain.profile.entity.Profile;
+import com.meoguri.linkocean.exception.LinkoceanRuntimeException;
 
 import lombok.Builder;
 import lombok.Getter;
@@ -188,7 +189,7 @@ public class Bookmark extends BaseIdEntity {
 			return arg == null ? null : Arrays.stream(Category.values())
 				.filter(category -> category.name.equals(arg))
 				.findAny()
-				.orElseThrow(() -> new IllegalArgumentException());
+				.orElseThrow(() -> new LinkoceanRuntimeException());
 		}
 	}
 }

--- a/src/main/java/com/meoguri/linkocean/domain/bookmark/entity/Bookmark.java
+++ b/src/main/java/com/meoguri/linkocean/domain/bookmark/entity/Bookmark.java
@@ -27,6 +27,7 @@ import com.meoguri.linkocean.domain.profile.entity.Profile;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
 
 /**
  * 북마크 (인터넷 즐겨찾기)
@@ -156,22 +157,30 @@ public class Bookmark extends BaseIdEntity {
 	/**
 	 * 북마크의 카테고리
 	 */
+	@Getter
+	@RequiredArgsConstructor
 	public enum Category {
 
-		SELF_DEVELOPMENT, //자기계발
-		HUMANITIES, //인문
-		POLITICS, //정치
-		SOCIAL, //사회
-		ART, //예술
-		SCIENCE, //과학
-		TECHNOLOGY, //기술
-		IT, //IT
-		HOME, //가정
-		HEALTH, //건강
-		TRAVEL, //여행
-		COOKING; //요리
+		SELF_DEVELOPMENT("자기계발"),
+		HUMANITIES("인문"),
+		POLITICS("정치"),
+		SOCIAL("사회"),
+		ART("예술"),
+		SCIENCE("과학"),
+		TECHNOLOGY("기술"),
+		IT("IT"),
+		HOME("가정"),
+		HEALTH("건강"),
+		TRAVEL("여행"),
+		COOKING("요리");
 
-		public static List<String> getAll() {
+		private final String name;
+
+		public static List<String> getEnglishNames() {
+			return Arrays.stream(Category.values()).map(v -> v.name).collect(toList());
+		}
+
+		public static List<String> getKoreanNames() {
 			return Arrays.stream(Category.values()).map(Category::getName).collect(toList());
 		}
 

--- a/src/main/java/com/meoguri/linkocean/domain/bookmark/entity/Bookmark.java
+++ b/src/main/java/com/meoguri/linkocean/domain/bookmark/entity/Bookmark.java
@@ -185,10 +185,10 @@ public class Bookmark extends BaseIdEntity {
 		}
 
 		public static Category of(String arg) {
-			return Arrays.stream(Category.values())
+			return arg == null ? null : Arrays.stream(Category.values())
 				.filter(category -> category.name.equals(arg))
 				.findAny()
-				.orElseThrow(() -> new IllegalStateException());
+				.orElseThrow(() -> new IllegalArgumentException());
 		}
 	}
 }

--- a/src/main/java/com/meoguri/linkocean/domain/bookmark/persistence/BookmarkRepository.java
+++ b/src/main/java/com/meoguri/linkocean/domain/bookmark/persistence/BookmarkRepository.java
@@ -22,4 +22,13 @@ public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
 		+ "join fetch bt.tag "
 		+ "where b.profile = :profile")
 	List<Bookmark> findByProfileFetchTags(Profile profile);
+
+	/**
+	 * 사용자가 작성한 북마크들의 카테고리 조회
+	 * @param profile
+	 * @return
+	 */
+	@Query("select distinct b.category from Bookmark b "
+		+ "where b.profile = :profile ")
+	List<String> findCategoryExistsBookmark(Profile profile);
 }

--- a/src/main/java/com/meoguri/linkocean/domain/bookmark/service/BookmarkServiceImpl.java
+++ b/src/main/java/com/meoguri/linkocean/domain/bookmark/service/BookmarkServiceImpl.java
@@ -1,6 +1,7 @@
 package com.meoguri.linkocean.domain.bookmark.service;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
@@ -61,7 +62,15 @@ public class BookmarkServiceImpl implements BookmarkService {
 
 		final Bookmark savedBookmark = bookmarkRepository.save(newBookmark);
 
-		convertTagNamesToTags(command.getTagNames()).forEach(savedBookmark::addBookmarkTag);
+		/**
+		 * 태그가 null로 들어올 때 처리가 안되었던 것 같습니다 -> 에러발생
+		 * 임시방편으로 리팩터링 해놨습니다!
+		 */
+		Optional.ofNullable(command.getTagNames()).ifPresent(
+			tagNames -> convertTagNamesToTags(tagNames).forEach(tag -> {
+				savedBookmark.addBookmarkTag(tag);
+			})
+		);
 
 		return savedBookmark.getId();
 	}

--- a/src/main/java/com/meoguri/linkocean/domain/bookmark/service/CategoryService.java
+++ b/src/main/java/com/meoguri/linkocean/domain/bookmark/service/CategoryService.java
@@ -6,4 +6,7 @@ public interface CategoryService {
 
 	/* 카테고리 목록 전체 조회 */
 	List<String> getAllCategories();
+
+	/* 사용자가 작성한 북마크가 존재하는 카테고리 목록 조회 */
+	List<String> getUsedCategories(long userId);
 }

--- a/src/main/java/com/meoguri/linkocean/domain/bookmark/service/CategoryServiceImpl.java
+++ b/src/main/java/com/meoguri/linkocean/domain/bookmark/service/CategoryServiceImpl.java
@@ -1,16 +1,39 @@
 package com.meoguri.linkocean.domain.bookmark.service;
 
+import static com.meoguri.linkocean.domain.bookmark.entity.Bookmark.*;
+
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
-import com.meoguri.linkocean.domain.bookmark.entity.Bookmark;
+import com.meoguri.linkocean.domain.bookmark.persistence.BookmarkRepository;
+import com.meoguri.linkocean.domain.profile.entity.Profile;
+import com.meoguri.linkocean.domain.profile.persistence.FindProfileByUserIdQuery;
+
+import lombok.RequiredArgsConstructor;
 
 @Service
+@Transactional
+@RequiredArgsConstructor
 public class CategoryServiceImpl implements CategoryService {
+
+	private final FindProfileByUserIdQuery findProfileByUserIdQuery;
+	private final BookmarkRepository bookmarkRepository;
 
 	@Override
 	public List<String> getAllCategories() {
-		return Bookmark.Category.getKoreanNames();
+		return Category.getKoreanNames();
+	}
+
+	@Override
+	public List<String> getUsedCategories(final long userId) {
+		final Profile writer = findProfileByUserIdQuery.findByUserId(userId);
+
+		return bookmarkRepository
+			.findCategoryExistsBookmark(writer).stream()
+			.map(name -> Category.valueOf(name).getName())
+			.collect(Collectors.toList());
 	}
 }

--- a/src/main/java/com/meoguri/linkocean/domain/bookmark/service/CategoryServiceImpl.java
+++ b/src/main/java/com/meoguri/linkocean/domain/bookmark/service/CategoryServiceImpl.java
@@ -33,7 +33,7 @@ public class CategoryServiceImpl implements CategoryService {
 
 		return bookmarkRepository
 			.findCategoryExistsBookmark(writer).stream()
-			.map(name -> Category.valueOf(name).getName())
+			.map(name -> Category.valueOf(name).getKorName())
 			.collect(Collectors.toList());
 	}
 }

--- a/src/main/java/com/meoguri/linkocean/domain/bookmark/service/CategoryServiceImpl.java
+++ b/src/main/java/com/meoguri/linkocean/domain/bookmark/service/CategoryServiceImpl.java
@@ -11,6 +11,6 @@ public class CategoryServiceImpl implements CategoryService {
 
 	@Override
 	public List<String> getAllCategories() {
-		return Bookmark.Category.getAll();
+		return Bookmark.Category.getKoreanNames();
 	}
 }

--- a/src/main/java/com/meoguri/linkocean/domain/profile/entity/FavoriteCategory.java
+++ b/src/main/java/com/meoguri/linkocean/domain/profile/entity/FavoriteCategory.java
@@ -35,4 +35,8 @@ public class FavoriteCategory extends BaseIdEntity {
 		this.category = Category.of(categoryName);
 	}
 
+	public String getCategoryName() {
+		return this.category.getName();
+	}
+
 }

--- a/src/main/java/com/meoguri/linkocean/domain/profile/entity/FavoriteCategory.java
+++ b/src/main/java/com/meoguri/linkocean/domain/profile/entity/FavoriteCategory.java
@@ -35,8 +35,4 @@ public class FavoriteCategory extends BaseIdEntity {
 		this.category = Category.of(categoryName);
 	}
 
-	public String getCategory() {
-		return category.getName();
-	}
-
 }

--- a/src/main/java/com/meoguri/linkocean/domain/profile/entity/FavoriteCategory.java
+++ b/src/main/java/com/meoguri/linkocean/domain/profile/entity/FavoriteCategory.java
@@ -36,7 +36,7 @@ public class FavoriteCategory extends BaseIdEntity {
 	}
 
 	public String getCategoryName() {
-		return this.category.getName();
+		return this.category.getKorName();
 	}
 
 }

--- a/src/main/java/com/meoguri/linkocean/domain/profile/entity/Profile.java
+++ b/src/main/java/com/meoguri/linkocean/domain/profile/entity/Profile.java
@@ -16,7 +16,6 @@ import javax.persistence.OneToMany;
 import javax.persistence.OneToOne;
 
 import com.meoguri.linkocean.domain.BaseIdEntity;
-import com.meoguri.linkocean.domain.bookmark.entity.Bookmark;
 import com.meoguri.linkocean.domain.user.entity.User;
 
 import lombok.Getter;
@@ -86,8 +85,7 @@ public class Profile extends BaseIdEntity {
 	 */
 	public List<String> getMyFavoriteCategories() {
 		return this.favoriteCategories.stream()
-			.map(FavoriteCategory::getCategory)
-			.map(Bookmark.Category::getName)
+			.map(FavoriteCategory::getCategoryName)
 			.collect(toList());
 	}
 
@@ -96,11 +94,12 @@ public class Profile extends BaseIdEntity {
 	 */
 	public void updateFavoriteCategories(final List<String> categories) {
 		// 기존 목록 중 업데이트 목록에 없다면 삭제
-		favoriteCategories.removeIf(fc -> !categories.contains(fc.getCategory()));
+		favoriteCategories.removeIf(fc -> !categories.contains(fc.getCategoryName()));
 
 		// 업데이트 목록 중 기존 목록에 포함되지 않았으면 추가
 		categories.stream()
-			.filter(c -> !favoriteCategories.stream().map(FavoriteCategory::getCategory).collect(toList()).contains(c))
+			.filter(c ->
+				!favoriteCategories.stream().map(FavoriteCategory::getCategoryName).collect(toList()).contains(c))
 			.forEach(c -> favoriteCategories.add(new FavoriteCategory(this, c)));
 	}
 }

--- a/src/main/java/com/meoguri/linkocean/domain/profile/entity/Profile.java
+++ b/src/main/java/com/meoguri/linkocean/domain/profile/entity/Profile.java
@@ -16,6 +16,7 @@ import javax.persistence.OneToMany;
 import javax.persistence.OneToOne;
 
 import com.meoguri.linkocean.domain.BaseIdEntity;
+import com.meoguri.linkocean.domain.bookmark.entity.Bookmark;
 import com.meoguri.linkocean.domain.user.entity.User;
 
 import lombok.Getter;
@@ -86,6 +87,7 @@ public class Profile extends BaseIdEntity {
 	public List<String> getMyFavoriteCategories() {
 		return this.favoriteCategories.stream()
 			.map(FavoriteCategory::getCategory)
+			.map(Bookmark.Category::getName)
 			.collect(toList());
 	}
 

--- a/src/main/java/com/meoguri/linkocean/domain/profile/service/dto/GetMyProfileResult.java
+++ b/src/main/java/com/meoguri/linkocean/domain/profile/service/dto/GetMyProfileResult.java
@@ -13,7 +13,7 @@ public final class GetMyProfileResult {
 	private final String username;
 	private final String imageUrl;
 	private final String bio;
-	private final List<String> categories;
+	private final List<String> favoriteCategories;
 	private final int followerCount;
 	private final int followeeCount;
 	private final boolean isFollow;

--- a/src/test/java/com/meoguri/linkocean/controller/BaseControllerTest.java
+++ b/src/test/java/com/meoguri/linkocean/controller/BaseControllerTest.java
@@ -1,6 +1,7 @@
 package com.meoguri.linkocean.controller;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import java.util.List;
@@ -23,6 +24,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.meoguri.linkocean.common.P6spyLogMessageFormatConfiguration;
 import com.meoguri.linkocean.configuration.security.oauth.SessionUser;
+import com.meoguri.linkocean.controller.bookmark.dto.RegisterBookmarkRequest;
 import com.meoguri.linkocean.controller.profile.dto.CreateProfileRequest;
 import com.meoguri.linkocean.domain.user.entity.User;
 import com.meoguri.linkocean.domain.user.repository.UserRepository;
@@ -58,9 +60,6 @@ public class BaseControllerTest {
 			.andExpect(status().isOk());
 	}
 
-	/*
-	일단 기본적으로 네이버로 설정하였습니다! 필요하다면 변경하세요!
-	 */
 	protected String 링크_메타데이터_조회(final String link) throws Exception {
 		mockMvc.perform(get(UriComponentsBuilder.fromUriString("/api/v1/linkmetadatas")
 				.queryParam("link", link)
@@ -71,6 +70,25 @@ public class BaseControllerTest {
 			.andExpect(status().isOk());
 
 		return link;
+	}
+
+	protected void 북마크_등록(
+		final String url,
+		final String category,
+		final List<String> tags,
+		final String openType) throws Exception {
+		mockMvc.perform(post("/api/v1/bookmarks").session(session)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(createJson(new RegisterBookmarkRequest(
+					url,
+					"title",
+					"memo",
+					category,
+					openType,
+					tags
+				))))
+			.andExpect(status().isOk())
+			.andDo(print());
 	}
 
 	protected String createJson(Object dto) throws JsonProcessingException {

--- a/src/test/java/com/meoguri/linkocean/controller/BaseControllerTest.java
+++ b/src/test/java/com/meoguri/linkocean/controller/BaseControllerTest.java
@@ -15,6 +15,7 @@ import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockHttpSession;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -26,6 +27,7 @@ import com.meoguri.linkocean.domain.user.entity.User;
 import com.meoguri.linkocean.domain.user.repository.UserRepository;
 
 @AutoConfigureMockMvc
+@Transactional
 @SpringBootTest
 @Import(P6spyLogMessageFormatConfiguration.class)
 public class BaseControllerTest {

--- a/src/test/java/com/meoguri/linkocean/controller/BaseControllerTest.java
+++ b/src/test/java/com/meoguri/linkocean/controller/BaseControllerTest.java
@@ -17,6 +17,7 @@ import org.springframework.mock.web.MockHttpSession;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.util.UriComponentsBuilder;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -55,6 +56,21 @@ public class BaseControllerTest {
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(createJson(new CreateProfileRequest(username, categories))))
 			.andExpect(status().isOk());
+	}
+
+	/*
+	일단 기본적으로 네이버로 설정하였습니다! 필요하다면 변경하세요!
+	 */
+	protected String 링크_메타데이터_조회(final String link) throws Exception {
+		mockMvc.perform(get(UriComponentsBuilder.fromUriString("/api/v1/linkmetadatas")
+				.queryParam("link", link)
+				.build()
+				.toUri())
+				.session(session)
+				.contentType(MediaType.APPLICATION_JSON))
+			.andExpect(status().isOk());
+
+		return link;
 	}
 
 	protected String createJson(Object dto) throws JsonProcessingException {

--- a/src/test/java/com/meoguri/linkocean/controller/BaseControllerTest.java
+++ b/src/test/java/com/meoguri/linkocean/controller/BaseControllerTest.java
@@ -61,7 +61,7 @@ public class BaseControllerTest {
 	}
 
 	protected String 링크_메타데이터_조회(final String link) throws Exception {
-		mockMvc.perform(get(UriComponentsBuilder.fromUriString("/api/v1/linkmetadatas")
+		mockMvc.perform(post(UriComponentsBuilder.fromUriString("/api/v1/linkmetadatas/obtain")
 				.queryParam("link", link)
 				.build()
 				.toUri())

--- a/src/test/java/com/meoguri/linkocean/controller/bookmark/BookmarkControllerTest.java
+++ b/src/test/java/com/meoguri/linkocean/controller/bookmark/BookmarkControllerTest.java
@@ -1,0 +1,46 @@
+package com.meoguri.linkocean.controller.bookmark;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+
+import com.meoguri.linkocean.controller.BaseControllerTest;
+import com.meoguri.linkocean.controller.bookmark.dto.RegisterBookmarkRequest;
+
+class BookmarkControllerTest extends BaseControllerTest {
+
+	private final String basePath = getBaseUrl(BookmarkController.class);
+
+	@WithMockUser(roles = "USER")
+	@Test
+	void 북마크_등록_Api_성공() throws Exception {
+		//given
+		유저_등록_로그인("hani@gmail.com", "GOOGLE");
+		프로필_등록("hani", List.of("정치", "인문", "사회"));
+		final String link = 링크_메타데이터_조회("http://www.naver.com");
+
+		final String title = "title1";
+		final String memo = "memo";
+		final String category = "인문";
+		final String openType = "private";
+
+		final RegisterBookmarkRequest registerBookmarkRequest =
+			new RegisterBookmarkRequest(link, title, memo, category, openType, null);
+
+		//when
+		mockMvc.perform(post(basePath).session(session)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(createJson(registerBookmarkRequest)))
+
+			//then
+			.andExpect(status().isOk())
+			.andDo(print());
+	}
+
+}

--- a/src/test/java/com/meoguri/linkocean/controller/category/CategoryControllerTest.java
+++ b/src/test/java/com/meoguri/linkocean/controller/category/CategoryControllerTest.java
@@ -29,18 +29,18 @@ class CategoryControllerTest extends BaseControllerTest {
 				jsonPath("$.count").value(12),
 				jsonPath("$.categories").isArray(),
 				jsonPath("$.categories", hasSize(12)),
-				jsonPath("$.categories[0]").value(Category.getAll().get(0)),
-				jsonPath("$.categories[1]").value(Category.getAll().get(1)),
-				jsonPath("$.categories[2]").value(Category.getAll().get(2)),
-				jsonPath("$.categories[3]").value(Category.getAll().get(3)),
-				jsonPath("$.categories[4]").value(Category.getAll().get(4)),
-				jsonPath("$.categories[5]").value(Category.getAll().get(5)),
-				jsonPath("$.categories[6]").value(Category.getAll().get(6)),
-				jsonPath("$.categories[7]").value(Category.getAll().get(7)),
-				jsonPath("$.categories[8]").value(Category.getAll().get(8)),
-				jsonPath("$.categories[9]").value(Category.getAll().get(9)),
-				jsonPath("$.categories[10]").value(Category.getAll().get(10)),
-				jsonPath("$.categories[11]").value(Category.getAll().get(11))
+				jsonPath("$.categories[0]").value(Category.getKoreanNames().get(0)),
+				jsonPath("$.categories[1]").value(Category.getKoreanNames().get(1)),
+				jsonPath("$.categories[2]").value(Category.getKoreanNames().get(2)),
+				jsonPath("$.categories[3]").value(Category.getKoreanNames().get(3)),
+				jsonPath("$.categories[4]").value(Category.getKoreanNames().get(4)),
+				jsonPath("$.categories[5]").value(Category.getKoreanNames().get(5)),
+				jsonPath("$.categories[6]").value(Category.getKoreanNames().get(6)),
+				jsonPath("$.categories[7]").value(Category.getKoreanNames().get(7)),
+				jsonPath("$.categories[8]").value(Category.getKoreanNames().get(8)),
+				jsonPath("$.categories[9]").value(Category.getKoreanNames().get(9)),
+				jsonPath("$.categories[10]").value(Category.getKoreanNames().get(10)),
+				jsonPath("$.categories[11]").value(Category.getKoreanNames().get(11))
 			).andDo(print());
 	}
 }

--- a/src/test/java/com/meoguri/linkocean/controller/linkmetadata/LinkMetadataControllerTest.java
+++ b/src/test/java/com/meoguri/linkocean/controller/linkmetadata/LinkMetadataControllerTest.java
@@ -26,7 +26,8 @@ class LinkMetadataControllerTest extends BaseControllerTest {
 
 		final String link = "http://www.naver.com";
 		//when
-		mockMvc.perform(get(UriComponentsBuilder.fromUriString(basePath)
+		mockMvc.perform(post(UriComponentsBuilder.fromUriString(basePath)
+				.pathSegment("obtain")
 				.queryParam("link", link)
 				.build()
 				.toUri())

--- a/src/test/java/com/meoguri/linkocean/controller/linkmetadata/LinkMetadataControllerTest.java
+++ b/src/test/java/com/meoguri/linkocean/controller/linkmetadata/LinkMetadataControllerTest.java
@@ -19,7 +19,7 @@ class LinkMetadataControllerTest extends BaseControllerTest {
 
 	@WithMockUser(roles = "USER")
 	@Test
-	void 링크메타데이터_제목_조회_API() throws Exception {
+	void 링크메타데이터_제목_조회_Api() throws Exception {
 		//given
 		유저_등록_로그인("hani@gmail.com", "GOOGLE");
 		프로필_등록("hani", List.of("정치", "인문", "사회"));

--- a/src/test/java/com/meoguri/linkocean/controller/linkmetadata/LinkMetadataControllerTest.java
+++ b/src/test/java/com/meoguri/linkocean/controller/linkmetadata/LinkMetadataControllerTest.java
@@ -1,0 +1,43 @@
+package com.meoguri.linkocean.controller.linkmetadata;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import com.meoguri.linkocean.controller.BaseControllerTest;
+
+class LinkMetadataControllerTest extends BaseControllerTest {
+
+	private final String basePath = getBaseUrl(LinkMetadataController.class);
+
+	@WithMockUser(roles = "USER")
+	@Test
+	void 링크메타데이터_제목_조회_API() throws Exception {
+		//given
+		유저_등록_로그인("hani@gmail.com", "GOOGLE");
+		프로필_등록("hani", List.of("정치", "인문", "사회"));
+
+		final String link = "http://www.naver.com";
+		//when
+		mockMvc.perform(get(UriComponentsBuilder.fromUriString(basePath)
+				.queryParam("link", link)
+				.build()
+				.toUri())
+				.session(session)
+				.contentType(MediaType.APPLICATION_JSON))
+
+			//then
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.title").exists())
+			.andDo(print());
+
+	}
+
+}

--- a/src/test/java/com/meoguri/linkocean/controller/profile/ProfileControllerTest.java
+++ b/src/test/java/com/meoguri/linkocean/controller/profile/ProfileControllerTest.java
@@ -1,5 +1,6 @@
 package com.meoguri.linkocean.controller.profile;
 
+import static org.hamcrest.Matchers.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -9,12 +10,10 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
-import org.springframework.transaction.annotation.Transactional;
 
 import com.meoguri.linkocean.controller.BaseControllerTest;
 import com.meoguri.linkocean.controller.profile.dto.CreateProfileRequest;
 
-@Transactional
 class ProfileControllerTest extends BaseControllerTest {
 
 	private final String basePath = getBaseUrl(ProfileController.class);
@@ -26,7 +25,7 @@ class ProfileControllerTest extends BaseControllerTest {
 		유저_등록_로그인("hani@gmail.com", "GOOGLE");
 
 		final String username = "hani";
-		final List<String> categories = List.of("ART", "SOCIAL", "IT");
+		final List<String> categories = List.of("인문", "정치", "사회");
 
 		final CreateProfileRequest createProfileRequest = new CreateProfileRequest(username, categories);
 
@@ -37,6 +36,45 @@ class ProfileControllerTest extends BaseControllerTest {
 
 			//then
 			.andExpect(status().isOk())
+			.andDo(print());
+	}
+
+	/*
+	저희 내 프로필 조회에서 내 Tag 목록과 내가 작성한 카테고리 목록 모두 작성하기로 했습니다.
+
+	아래의 내용들은 아직 API가 개발되지 않아서 추후 테스트를 보강하도록 하겠습니다.
+	1. 내가 작성한 카터고리 목록 - 완료
+	2. 내 Tag 목록
+	3. 팔로워, 팔로위 수
+	4. Bio, imageUrl
+	 */
+	@WithMockUser(roles = "USER")
+	@Test
+	void 내프로필_조회_Api_성공() throws Exception {
+		//given
+		유저_등록_로그인("hani@gmail.com", "GOOGLE");
+		프로필_등록("hani", List.of("인문", "정치", "사회"));
+		final String url = 링크_메타데이터_조회("http://www.naver.com");
+		북마크_등록(url, "인문", null, "private");
+
+		//when
+		mockMvc.perform(get(basePath + "/me").session(session)
+				.contentType(MediaType.APPLICATION_JSON))
+
+			//then
+			.andExpect(status().isOk())
+			.andExpectAll(
+				jsonPath("$.profileId").exists(),
+				jsonPath("$.imageUrl").isEmpty(),
+				jsonPath("$.favoriteCategories", hasSize(3)),
+				jsonPath("$.username").value("hani"),
+				jsonPath("$.bio").isEmpty(),
+				jsonPath("$.followerCount").value(0),
+				jsonPath("$.followeeCount").value(0),
+				jsonPath("$.tags", hasSize(0)),
+				jsonPath("$.categories", hasSize(1))
+
+			)
 			.andDo(print());
 	}
 }

--- a/src/test/java/com/meoguri/linkocean/controller/user/LoginControllerTest.java
+++ b/src/test/java/com/meoguri/linkocean/controller/user/LoginControllerTest.java
@@ -23,7 +23,7 @@ class LoginControllerTest extends BaseControllerTest {
 	void 로그인_성공후_Profile_소지여부조회_Api_hasProfile_true() throws Exception {
 		//given
 		유저_등록_로그인("hani@gmail.com", "GOOGLE");
-		프로필_등록("hani", List.of("ART", "SOCIAL", "IT"));
+		프로필_등록("hani", List.of("정치", "인문", "사회"));
 
 		//when
 		mockMvc.perform(get(basePath + "/success").session(session)

--- a/src/test/java/com/meoguri/linkocean/controller/user/LoginControllerTest.java
+++ b/src/test/java/com/meoguri/linkocean/controller/user/LoginControllerTest.java
@@ -9,11 +9,9 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
-import org.springframework.transaction.annotation.Transactional;
 
 import com.meoguri.linkocean.controller.BaseControllerTest;
 
-@Transactional
 class LoginControllerTest extends BaseControllerTest {
 
 	private final String basePath = getBaseUrl(LoginController.class);

--- a/src/test/java/com/meoguri/linkocean/domain/bookmark/entity/BookmarkTest.java
+++ b/src/test/java/com/meoguri/linkocean/domain/bookmark/entity/BookmarkTest.java
@@ -27,7 +27,7 @@ class BookmarkTest {
 		final Profile profile = createProfile();
 		final LinkMetadata linkMetadata = createLinkMetadata();
 		final String openType = "all";
-		final String category = "it";
+		final String category = "인문";
 
 		//when
 		final Bookmark bookmark = Bookmark.builder()
@@ -64,7 +64,7 @@ class BookmarkTest {
 		final String title = RandomString.make(MAX_PROFILE_USERNAME_LENGTH + 1);
 		final LinkMetadata linkMetadata = createLinkMetadata();
 		final String memo = "memo";
-		final String category = "it";
+		final String category = "인문";
 		final String openType = "all";
 
 		//when then
@@ -117,7 +117,7 @@ class BookmarkTest {
 		final Bookmark bookmark = createBookmark();
 		final String updatedTitle = "updatedTitle";
 		final String updatedMemo = "updatedMemo";
-		final String category = "it";
+		final String category = "인문";
 		final String openType = "partial";
 		final List<Tag> tags = List.of(new Tag("tag1"), new Tag("tag2"));
 
@@ -142,7 +142,7 @@ class BookmarkTest {
 		final Bookmark bookmark = createBookmark();
 		final String invalidTitle = RandomString.make(MAX_PROFILE_USERNAME_LENGTH + 1);
 		final String updatedMemo = "updatedMemo";
-		final String category = "it";
+		final String category = "인문";
 		final String openType = "partial";
 		final List<Tag> tags = List.of(new Tag("tag1"), new Tag("tag2"));
 
@@ -157,7 +157,7 @@ class BookmarkTest {
 		final Bookmark bookmark = createBookmark();
 		final String updatedTitle = "updatedTitle";
 		final String updatedMemo = "updatedMemo";
-		final String category = "it";
+		final String category = "인문";
 		final String openType = "partial";
 		final List<Tag> tags = List.of(
 			new Tag("tag1"),

--- a/src/test/java/com/meoguri/linkocean/domain/bookmark/persistence/BookmarkRepositoryTest.java
+++ b/src/test/java/com/meoguri/linkocean/domain/bookmark/persistence/BookmarkRepositoryTest.java
@@ -103,9 +103,9 @@ class BookmarkRepositoryTest {
 	@Test
 	void 사용자의_전체_북마크조회_태그_까지_페치_성공() {
 		//given
-		final Bookmark bookmark1 = createBookmark(profile, link, "bookmark1");
-		final Bookmark bookmark2 = createBookmark(profile, link, "bookmark2");
-		final Bookmark bookmark3 = createBookmark(profile, link, "bookmark3");
+		final Bookmark bookmark1 = createBookmark(profile, link, "bookmark1", "인문");
+		final Bookmark bookmark2 = createBookmark(profile, link, "bookmark2", "인문");
+		final Bookmark bookmark3 = createBookmark(profile, link, "bookmark3", "인문");
 
 		bookmark1.addBookmarkTag(tag1);
 		bookmark1.addBookmarkTag(tag2);
@@ -137,5 +137,22 @@ class BookmarkRepositoryTest {
 				tuple("bookmark2", List.of("tag2", "tag3")),
 				tuple("bookmark3", List.of("tag3"))
 			);
+	}
+
+	@Test
+	void 게시글이_존재하는_카테고리이름_반환() {
+		//given
+		bookmarkRepository.save(createBookmark(profile, link, "인문"));
+		bookmarkRepository.save(createBookmark(profile, link, "인문"));
+		bookmarkRepository.save(createBookmark(profile, link, "인문"));
+		bookmarkRepository.save(createBookmark(profile, link, "사회"));
+		bookmarkRepository.save(createBookmark(profile, link, "사회"));
+		bookmarkRepository.save(createBookmark(profile, link, "과학"));
+
+		//when
+		final List<String> categories = bookmarkRepository.findCategoryExistsBookmark(profile);
+
+		//then
+		assertThat(categories).contains("HUMANITIES", "SOCIAL", "SCIENCE");
 	}
 }

--- a/src/test/java/com/meoguri/linkocean/domain/bookmark/persistence/ReactionRepositoryTest.java
+++ b/src/test/java/com/meoguri/linkocean/domain/bookmark/persistence/ReactionRepositoryTest.java
@@ -53,7 +53,7 @@ class ReactionRepositoryTest {
 				.linkMetadata(linkMetadataRepository.save(createLinkMetadata()))
 				.title("title")
 				.memo("memo")
-				.category("it")
+				.category("인문")
 				.openType("all")
 				.build());
 	}

--- a/src/test/java/com/meoguri/linkocean/domain/bookmark/service/BookmarkServiceImplTest.java
+++ b/src/test/java/com/meoguri/linkocean/domain/bookmark/service/BookmarkServiceImplTest.java
@@ -73,7 +73,7 @@ class BookmarkServiceImplTest {
 		//given
 		final RegisterBookmarkCommand command =
 
-			new RegisterBookmarkCommand(userId, url, "title", "memo", "it", "all", List.of("tag1", "tag2"));
+			new RegisterBookmarkCommand(userId, url, "title", "memo", "인문", "all", List.of("tag1", "tag2"));
 
 		//when
 		final long savedBookmarkId = bookmarkService.registerBookmark(command);
@@ -150,7 +150,7 @@ class BookmarkServiceImplTest {
 				bookmark.getId(),
 				"updatedTitle",
 				"updatedMemo",
-				"home",
+				"인문",
 				"private",
 				List.of("tag1", "tag2")
 			);

--- a/src/test/java/com/meoguri/linkocean/domain/bookmark/service/BookmarkServiceImplTest.java
+++ b/src/test/java/com/meoguri/linkocean/domain/bookmark/service/BookmarkServiceImplTest.java
@@ -258,7 +258,7 @@ class BookmarkServiceImplTest {
 			.title("title")
 			.linkMetadata(linkMetadata)
 			.memo("dream company")
-			.category("it")
+			.category("인문")
 			.openType("all")
 			.build();
 

--- a/src/test/java/com/meoguri/linkocean/domain/bookmark/service/CategoryServiceImplTest.java
+++ b/src/test/java/com/meoguri/linkocean/domain/bookmark/service/CategoryServiceImplTest.java
@@ -70,7 +70,7 @@ class CategoryServiceImplTest {
 
 		//then
 		final List<String> expectedCategories
-			= Arrays.stream(Category.values()).map(Category::getName).collect(toList());
+			= Arrays.stream(Category.values()).map(Category::getKorName).collect(toList());
 		assertThat(allCategories)
 			.containsExactlyElementsOf(expectedCategories);
 	}

--- a/src/test/java/com/meoguri/linkocean/domain/bookmark/service/CategoryServiceImplTest.java
+++ b/src/test/java/com/meoguri/linkocean/domain/bookmark/service/CategoryServiceImplTest.java
@@ -1,24 +1,72 @@
 package com.meoguri.linkocean.domain.bookmark.service;
 
+import static com.meoguri.linkocean.domain.util.Fixture.*;
 import static java.util.stream.Collectors.*;
 import static org.assertj.core.api.Assertions.*;
 
 import java.util.Arrays;
 import java.util.List;
 
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.meoguri.linkocean.domain.bookmark.entity.Bookmark.Category;
+import com.meoguri.linkocean.domain.bookmark.entity.Tag;
+import com.meoguri.linkocean.domain.bookmark.persistence.BookmarkRepository;
+import com.meoguri.linkocean.domain.linkmetadata.entity.LinkMetadata;
+import com.meoguri.linkocean.domain.linkmetadata.persistence.LinkMetadataRepository;
+import com.meoguri.linkocean.domain.profile.entity.Profile;
+import com.meoguri.linkocean.domain.profile.persistence.ProfileRepository;
+import com.meoguri.linkocean.domain.user.entity.User;
+import com.meoguri.linkocean.domain.user.repository.UserRepository;
 
-/**
- * Spring 에 의존적이지 않아 SpringBootTest 추가하지 않음
- */
+@SpringBootTest
+@Transactional
 class CategoryServiceImplTest {
+
+	@PersistenceContext
+	private EntityManager em;
+
+	@Autowired
+	private BookmarkRepository bookmarkRepository;
+
+	@Autowired
+	private LinkMetadataRepository linkMetadataRepository;
+
+	@Autowired
+	private ProfileRepository profileRepository;
+
+	@Autowired
+	private UserRepository userRepository;
+
+	@Autowired
+	private CategoryService categoryService;
+
+	private User user;
+	private Profile profile;
+	private LinkMetadata link;
+	private Tag tag1;
+	private Tag tag2;
+	private Tag tag3;
+
+	@BeforeEach
+	void setUp() {
+		// 유저, 프로필, 링크 셋업
+		user = userRepository.save(createUser());
+		profile = profileRepository.save(createProfile(user));
+		link = linkMetadataRepository.save(createLinkMetadata());
+	}
 
 	@Test
 	void 카테고리_전체조회_성공() {
 		//when
-		final List<String> allCategories = new CategoryServiceImpl().getAllCategories();
+		final List<String> allCategories = categoryService.getAllCategories();
 
 		//then
 		final List<String> expectedCategories
@@ -26,4 +74,22 @@ class CategoryServiceImplTest {
 		assertThat(allCategories)
 			.containsExactlyElementsOf(expectedCategories);
 	}
+
+	@Test
+	void 사용자가_작성한_북마크가있는_카테고리_조회_성공() {
+		//given
+		bookmarkRepository.save(createBookmark(profile, link, "인문"));
+		bookmarkRepository.save(createBookmark(profile, link, "인문"));
+		bookmarkRepository.save(createBookmark(profile, link, "인문"));
+		bookmarkRepository.save(createBookmark(profile, link, "사회"));
+		bookmarkRepository.save(createBookmark(profile, link, "사회"));
+		bookmarkRepository.save(createBookmark(profile, link, "과학"));
+
+		//when
+		final List<String> categories = categoryService.getUsedCategories(user.getId());
+
+		//then
+		assertThat(categories).contains("인문", "사회", "과학");
+	}
+
 }

--- a/src/test/java/com/meoguri/linkocean/domain/bookmark/service/TagServiceImplTest.java
+++ b/src/test/java/com/meoguri/linkocean/domain/bookmark/service/TagServiceImplTest.java
@@ -76,9 +76,9 @@ class TagServiceImplTest {
 	@Test
 	void 태그_목록_조회_성공() {
 		//given
-		final Bookmark bookmark1 = createBookmark(profile, link, "bookmark1");
-		final Bookmark bookmark2 = createBookmark(profile, link, "bookmark2");
-		final Bookmark bookmark3 = createBookmark(profile, link, "bookmark3");
+		final Bookmark bookmark1 = createBookmark(profile, link, "bookmark1", "인문");
+		final Bookmark bookmark2 = createBookmark(profile, link, "bookmark2", "인문");
+		final Bookmark bookmark3 = createBookmark(profile, link, "bookmark3", "인문");
 
 		bookmark1.addBookmarkTag(tag1);
 		bookmark1.addBookmarkTag(tag2);

--- a/src/test/java/com/meoguri/linkocean/domain/profile/entity/FavoriteCategoryTest.java
+++ b/src/test/java/com/meoguri/linkocean/domain/profile/entity/FavoriteCategoryTest.java
@@ -6,6 +6,7 @@ import static org.assertj.core.api.Assertions.*;
 import org.junit.jupiter.api.Test;
 
 import com.meoguri.linkocean.domain.bookmark.entity.Bookmark;
+import com.meoguri.linkocean.exception.LinkoceanRuntimeException;
 
 class FavoriteCategoryTest {
 
@@ -31,7 +32,7 @@ class FavoriteCategoryTest {
 		final String category = "undefined category";
 
 		//when then
-		assertThatIllegalArgumentException()
-			.isThrownBy(() -> new FavoriteCategory(profile, category));
+		assertThatThrownBy(() -> new FavoriteCategory(profile, category))
+			.isInstanceOf(LinkoceanRuntimeException.class);
 	}
 }

--- a/src/test/java/com/meoguri/linkocean/domain/profile/entity/FavoriteCategoryTest.java
+++ b/src/test/java/com/meoguri/linkocean/domain/profile/entity/FavoriteCategoryTest.java
@@ -5,13 +5,15 @@ import static org.assertj.core.api.Assertions.*;
 
 import org.junit.jupiter.api.Test;
 
+import com.meoguri.linkocean.domain.bookmark.entity.Bookmark;
+
 class FavoriteCategoryTest {
 
 	@Test
 	void 선호_카테고리_생성_성공() {
 		//given
 		final Profile profile = createProfile();
-		final String category = "it";
+		final String category = "인문";
 
 		//when
 		final FavoriteCategory favoriteCategory = new FavoriteCategory(profile, category);
@@ -19,7 +21,7 @@ class FavoriteCategoryTest {
 		//then
 		assertThat(favoriteCategory).isNotNull()
 			.extracting(FavoriteCategory::getProfile, FavoriteCategory::getCategory)
-			.containsExactly(profile, category);
+			.containsExactly(profile, Bookmark.Category.of(category));
 	}
 
 	@Test

--- a/src/test/java/com/meoguri/linkocean/domain/profile/service/ProfileServiceImplTest.java
+++ b/src/test/java/com/meoguri/linkocean/domain/profile/service/ProfileServiceImplTest.java
@@ -88,7 +88,7 @@ class ProfileServiceImplTest {
 				false
 			);
 
-			assertThat(result.getCategories()).containsExactly("인문", "정치");
+			assertThat(result.getFavoriteCategories()).containsExactly("인문", "정치");
 		}
 
 		@Test
@@ -126,7 +126,7 @@ class ProfileServiceImplTest {
 				"updated bio"
 			);
 
-			assertThat(result.getCategories()).containsExactly("인문", "과학");
+			assertThat(result.getFavoriteCategories()).containsExactly("인문", "과학");
 		}
 	}
 

--- a/src/test/java/com/meoguri/linkocean/domain/profile/service/ProfileServiceImplTest.java
+++ b/src/test/java/com/meoguri/linkocean/domain/profile/service/ProfileServiceImplTest.java
@@ -106,7 +106,7 @@ class ProfileServiceImplTest {
 				"papa",
 				"updated image url",
 				"updated bio",
-				List.of("it", "science")
+				List.of("인문", "과학")
 			);
 
 			profileService.updateProfile(updateCommand);
@@ -126,7 +126,7 @@ class ProfileServiceImplTest {
 				"updated bio"
 			);
 
-			assertThat(result.getCategories()).containsExactly("it", "science");
+			assertThat(result.getCategories()).containsExactly("인문", "과학");
 		}
 	}
 

--- a/src/test/java/com/meoguri/linkocean/domain/profile/service/ProfileServiceImplTest.java
+++ b/src/test/java/com/meoguri/linkocean/domain/profile/service/ProfileServiceImplTest.java
@@ -54,7 +54,7 @@ class ProfileServiceImplTest {
 			userId = user.getId();
 
 			profile = createProfile(user);
-			categories = List.of("it", "self_development");
+			categories = List.of("인문", "정치");
 		}
 
 		@Test
@@ -88,7 +88,7 @@ class ProfileServiceImplTest {
 				false
 			);
 
-			assertThat(result.getCategories()).containsExactly("it", "self_development");
+			assertThat(result.getCategories()).containsExactly("인문", "정치");
 		}
 
 		@Test

--- a/src/test/java/com/meoguri/linkocean/domain/util/Fixture.java
+++ b/src/test/java/com/meoguri/linkocean/domain/util/Fixture.java
@@ -45,7 +45,7 @@ public final class Fixture {
 			.title(title)
 			.linkMetadata(linkMetadata)
 			.memo("dream company")
-			.category("it")
+			.category("IT")
 			.openType("all")
 			.build();
 	}

--- a/src/test/java/com/meoguri/linkocean/domain/util/Fixture.java
+++ b/src/test/java/com/meoguri/linkocean/domain/util/Fixture.java
@@ -30,22 +30,27 @@ public final class Fixture {
 
 	public static Bookmark createBookmark() {
 
-		return createBookmark(createProfile(), createLinkMetadata());
+		return createBookmark(createProfile(), createLinkMetadata(), "인문");
 	}
 
 	public static Bookmark createBookmark(Profile profile, LinkMetadata linkMetadata) {
 
-		return createBookmark(profile, linkMetadata, "title");
+		return createBookmark(profile, linkMetadata, "title", "인문");
 	}
 
-	public static Bookmark createBookmark(Profile profile, LinkMetadata linkMetadata, String title) {
+	public static Bookmark createBookmark(Profile profile, LinkMetadata linkMetadata, String category) {
+
+		return createBookmark(profile, linkMetadata, "title", category);
+	}
+
+	public static Bookmark createBookmark(Profile profile, LinkMetadata linkMetadata, String title, String category) {
 
 		return Bookmark.builder()
 			.profile(profile)
 			.title(title)
 			.linkMetadata(linkMetadata)
 			.memo("dream company")
-			.category("IT")
+			.category(category)
 			.openType("all")
 			.build();
 	}


### PR DESCRIPTION
<!-- PR 제목 양식 예시: [LO-N] 회원 기능 도메인 -->

## 🛠️ 작업 내용
- Category 목록 영어 -> 한글로 리팩터링, 파급효과 정리
- 게시글이 존재하는 카테고리 조회 서비스 개발 & 내 정보 조회 보시면 됩니다!
- 링크_메타데이터_조회 Controller Test
- 북마크 생성 Controller Test
- 내정보 조회 Controller Test

## 🗨️ 기타
<!-- PR 포인트 혹은 궁금한 점 등등 적어주시면 됩니다. 없으시면 지워주세요 -->
- 

## 😎 리뷰어
@ndy2 , @NewEgoDoc, @hyuk0309

