### PR TITLE
[LO-97] 북마크 제목, 메모, 카테고리 Null인 경우 NPE 이슈 해결

### DIFF
--- a/src/main/java/com/meoguri/linkocean/configuration/DateFormatConfig.java
+++ b/src/main/java/com/meoguri/linkocean/configuration/DateFormatConfig.java
@@ -1,0 +1,46 @@
+package com.meoguri.linkocean.configuration;
+
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.TimeZone;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.jackson.Jackson2ObjectMapperBuilderCustomizer;
+import org.springframework.boot.jackson.JsonComponent;
+import org.springframework.context.annotation.Bean;
+
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
+
+@JsonComponent
+public class DateFormatConfig {
+
+	@Value("${spring.jackson.date-format:yyyy-MM-dd}")
+	private String pattern;
+
+	@Bean
+	public Jackson2ObjectMapperBuilderCustomizer jackson2ObjectMapperBuilder() {
+		return builder -> {
+			TimeZone tz = TimeZone.getTimeZone("Asia/Seoul");
+			DateFormat df = new SimpleDateFormat(pattern);
+			df.setTimeZone(tz);
+			builder.failOnEmptyBeans(false)
+				.failOnUnknownProperties(false)
+				.featuresToDisable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+				.dateFormat(df);
+		};
+	}
+
+	@Bean
+	public LocalDateTimeSerializer localDateTimeDeserializer() {
+		return new LocalDateTimeSerializer(DateTimeFormatter.ofPattern(pattern));
+	}
+
+	@Bean
+	public Jackson2ObjectMapperBuilderCustomizer jackson2ObjectMapperBuilderCustomizer(
+		LocalDateTimeSerializer localDateTimeDeserializer) {
+		return builder -> builder.serializerByType(LocalDateTime.class, localDateTimeDeserializer);
+	}
+}

--- a/src/main/java/com/meoguri/linkocean/controller/bookmark/dto/GetBookmarkResponse.java
+++ b/src/main/java/com/meoguri/linkocean/controller/bookmark/dto/GetBookmarkResponse.java
@@ -1,10 +1,9 @@
 package com.meoguri.linkocean.controller.bookmark.dto;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.meoguri.linkocean.domain.bookmark.service.dto.GetBookmarkResult;
 import com.meoguri.linkocean.domain.bookmark.service.dto.GetBookmarkResult.GetBookmarkProfileResult;
@@ -26,9 +25,7 @@ public final class GetBookmarkResponse {
 	private final String openType;
 
 	private final Boolean isFavorite;
-
-	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
-	private final LocalDateTime updatedAt;
+	private final LocalDate updatedAt;
 	private final List<String> tags;
 	private final Map<String, Long> reactionCount;
 	private final GetBookmarkProfileResponse profile;
@@ -42,7 +39,7 @@ public final class GetBookmarkResponse {
 			result.getMemo(),
 			result.getOpenType(),
 			result.isFavorite(),
-			result.getUpdatedAt(),
+			result.getUpdatedAt().toLocalDate(),
 			result.getTags(),
 			result.getReactionCount(),
 			GetBookmarkProfileResponse.of(result.getProfile())

--- a/src/main/java/com/meoguri/linkocean/controller/bookmark/dto/GetBookmarkResponse.java
+++ b/src/main/java/com/meoguri/linkocean/controller/bookmark/dto/GetBookmarkResponse.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.meoguri.linkocean.domain.bookmark.service.dto.GetBookmarkResult;
 import com.meoguri.linkocean.domain.bookmark.service.dto.GetBookmarkResult.GetBookmarkProfileResult;
@@ -23,7 +24,10 @@ public final class GetBookmarkResponse {
 	private final String category;
 	private final String memo;
 	private final String openType;
-	private final boolean isFavorite;
+
+	private final Boolean isFavorite;
+
+	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
 	private final LocalDateTime updatedAt;
 	private final List<String> tags;
 	private final Map<String, Long> reactionCount;
@@ -51,8 +55,10 @@ public final class GetBookmarkResponse {
 
 		private final long profileId;
 		private final String username;
+
+		@JsonProperty("imageUrl")
 		private final String image;
-		private final boolean isFollow;
+		private final Boolean isFollow;
 
 		public static GetBookmarkProfileResponse of(final GetBookmarkProfileResult profile) {
 			return new GetBookmarkProfileResponse(

--- a/src/main/java/com/meoguri/linkocean/domain/bookmark/entity/Bookmark.java
+++ b/src/main/java/com/meoguri/linkocean/domain/bookmark/entity/Bookmark.java
@@ -12,6 +12,7 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -139,12 +140,20 @@ public class Bookmark extends BaseIdEntity {
 			.collect(toList());
 	}
 
+	public String getTitle() {
+		return Optional.ofNullable(title).orElse("");
+	}
+
+	public String getMemo() {
+		return Optional.ofNullable(memo).orElse("");
+	}
+
 	public List<String> getTagNames() {
 		return bookmarkTags.stream().map(BookmarkTag::getTagName).collect(toList());
 	}
 
 	public String getCategory() {
-		return category.getKorName();
+		return category == null ? "" : category.getKorName();
 	}
 
 	public String getOpenType() {

--- a/src/main/java/com/meoguri/linkocean/domain/bookmark/entity/Bookmark.java
+++ b/src/main/java/com/meoguri/linkocean/domain/bookmark/entity/Bookmark.java
@@ -12,7 +12,6 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Optional;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -140,20 +139,12 @@ public class Bookmark extends BaseIdEntity {
 			.collect(toList());
 	}
 
-	public String getTitle() {
-		return Optional.ofNullable(title).orElse("");
-	}
-
-	public String getMemo() {
-		return Optional.ofNullable(memo).orElse("");
-	}
-
 	public List<String> getTagNames() {
 		return bookmarkTags.stream().map(BookmarkTag::getTagName).collect(toList());
 	}
 
 	public String getCategory() {
-		return category == null ? "" : category.getKorName();
+		return category == null ? null : category.getKorName();
 	}
 
 	public String getOpenType() {

--- a/src/test/java/com/meoguri/linkocean/controller/bookmark/BookmarkControllerTest.java
+++ b/src/test/java/com/meoguri/linkocean/controller/bookmark/BookmarkControllerTest.java
@@ -59,7 +59,7 @@ class BookmarkControllerTest extends BaseControllerTest {
 
 	@WithMockUser(roles = "USER")
 	@Test
-	void 카테고리_없는_북마크_상세_조회_Api_성공() throws Exception {
+	void 제목_메모_카테고리_없는_북마크_상세_조회_Api_성공() throws Exception {
 		//given
 		유저_등록_로그인("crush@gmail.com", "GOOGLE");
 		프로필_등록("crush", List.of("IT", "인문"));
@@ -72,8 +72,8 @@ class BookmarkControllerTest extends BaseControllerTest {
 			new RegisterBookmarkCommand(
 				userId,
 				"https://www.naver.com",
-				"title",
-				"memo",
+				null,
+				null,
 				null,
 				"all",
 				List.of("tag1", "tag2"))

--- a/src/test/java/com/meoguri/linkocean/controller/bookmark/BookmarkControllerTest.java
+++ b/src/test/java/com/meoguri/linkocean/controller/bookmark/BookmarkControllerTest.java
@@ -1,5 +1,7 @@
 package com.meoguri.linkocean.controller.bookmark;
 
+import static java.time.format.DateTimeFormatter.*;
+import static org.hamcrest.Matchers.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -7,13 +9,25 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 
+import com.meoguri.linkocean.configuration.security.oauth.SessionUser;
 import com.meoguri.linkocean.controller.BaseControllerTest;
 import com.meoguri.linkocean.controller.bookmark.dto.RegisterBookmarkRequest;
+import com.meoguri.linkocean.domain.bookmark.entity.Bookmark;
+import com.meoguri.linkocean.domain.bookmark.persistence.BookmarkRepository;
+import com.meoguri.linkocean.domain.bookmark.service.BookmarkService;
+import com.meoguri.linkocean.domain.bookmark.service.dto.RegisterBookmarkCommand;
 
 class BookmarkControllerTest extends BaseControllerTest {
+
+	@Autowired
+	private BookmarkService bookmarkService;
+
+	@Autowired
+	private BookmarkRepository bookmarkRepository;
 
 	private final String basePath = getBaseUrl(BookmarkController.class);
 
@@ -41,6 +55,55 @@ class BookmarkControllerTest extends BaseControllerTest {
 			//then
 			.andExpect(status().isOk())
 			.andDo(print());
+	}
+
+	@WithMockUser(roles = "USER")
+	@Test
+	void 카테고리_없는_북마크_상세_조회_Api_성공() throws Exception {
+		//given
+		유저_등록_로그인("crush@gmail.com", "GOOGLE");
+		프로필_등록("crush", List.of("IT", "인문"));
+
+		링크_메타데이터_조회("http://www.naver.com");
+
+		final Long userId = ((SessionUser)session.getAttribute("user")).getId();
+
+		final long savedBookmarkId = bookmarkService.registerBookmark(
+			new RegisterBookmarkCommand(
+				userId,
+				"https://www.naver.com",
+				"title",
+				"memo",
+				null,
+				"all",
+				List.of("tag1", "tag2"))
+		);
+
+		Bookmark savedBookmark = bookmarkRepository.findByIdFetchProfileAndLinkMetadataAndTags(savedBookmarkId).get();
+
+		//when then
+		mockMvc.perform(get(basePath + "/" + savedBookmarkId).session(session))
+			.andExpect(status().isOk())
+			.andExpectAll(
+				jsonPath("$.title").value(savedBookmark.getTitle()),
+				jsonPath("$.url").value(savedBookmark.getUrl()),
+				jsonPath("$.imageUrl").value(savedBookmark.getLinkMetadata().getImage()),
+				jsonPath("$.category").value(savedBookmark.getCategory()),
+				jsonPath("$.memo").value(savedBookmark.getMemo()),
+				jsonPath("$.openType").value(savedBookmark.getOpenType()),
+				jsonPath("$.isFavorite").value(false),
+				jsonPath("$.updatedAt").value(savedBookmark.getUpdatedAt().format(ofPattern("yyyy-MM-dd"))),
+				jsonPath("$.tags").isArray(),
+				jsonPath("$.tags", hasSize(savedBookmark.getTagNames().size())),
+				jsonPath("$.tags[0]").value(savedBookmark.getTagNames().get(0)),
+				jsonPath("$.tags[1]").value(savedBookmark.getTagNames().get(1)),
+				jsonPath("$.reactionCount.like").value(0),
+				jsonPath("$.reactionCount.hate").value(0),
+				jsonPath("$.profile.profileId").value(savedBookmark.getProfile().getId()),
+				jsonPath("$.profile.username").value(savedBookmark.getProfile().getUsername()),
+				jsonPath("$.profile.imageUrl").value(savedBookmark.getProfile().getImage()),
+				jsonPath("$.profile.isFollow").value(false)
+			).andDo(print());
 	}
 
 }

--- a/src/test/java/com/meoguri/linkocean/domain/bookmark/entity/BookmarkTest.java
+++ b/src/test/java/com/meoguri/linkocean/domain/bookmark/entity/BookmarkTest.java
@@ -5,7 +5,6 @@ import static com.meoguri.linkocean.domain.util.Fixture.*;
 import static org.assertj.core.api.Assertions.*;
 
 import java.util.List;
-import java.util.Optional;
 
 import org.assertj.core.internal.bytebuddy.utility.RandomString;
 import org.junit.jupiter.api.Test;
@@ -51,9 +50,9 @@ class BookmarkTest {
 				Bookmark::getOpenType
 			).containsExactly(
 				profile,
-				Optional.ofNullable(title).orElse(""),
+				title,
 				linkMetadata,
-				Optional.ofNullable(memo).orElse(""),
+				memo,
 				category,
 				openType);
 

--- a/src/test/java/com/meoguri/linkocean/domain/bookmark/entity/BookmarkTest.java
+++ b/src/test/java/com/meoguri/linkocean/domain/bookmark/entity/BookmarkTest.java
@@ -5,6 +5,7 @@ import static com.meoguri.linkocean.domain.util.Fixture.*;
 import static org.assertj.core.api.Assertions.*;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.assertj.core.internal.bytebuddy.utility.RandomString;
 import org.junit.jupiter.api.Test;
@@ -48,7 +49,13 @@ class BookmarkTest {
 				Bookmark::getMemo,
 				Bookmark::getCategory,
 				Bookmark::getOpenType
-			).containsExactly(profile, title, linkMetadata, memo, category, openType);
+			).containsExactly(
+				profile,
+				Optional.ofNullable(title).orElse(""),
+				linkMetadata,
+				Optional.ofNullable(memo).orElse(""),
+				category,
+				openType);
 
 		assertThat(bookmark)
 			.extracting(


### PR DESCRIPTION
## 🛠️ 작업 내용
- 북마크 제목, 메모, 카테고리 `null`인 경우 `NPE` 이슈 해결

## 🗨️ 기타
- `bookmark` 엔티티에서 `null`을 허용하는 필드들은 `getter`을 명시적으로 만들고, `null`인 경우 `""`을 반환하도록 수정했습니다.
- 관련 테스트 코드를 작성했습니다. 테스트 코드를 작성하면 `BaseControllerTest`의 `북마크_등록 API`를 활용하려 했지만 저장한 북마크의 식별번호를 알 수 없어 사용하지 못했습니다.

## 😎 리뷰어
@ndy2 , @jk05018 , @NewEgoDoc