### PR TITLE
[LO-103] 프로필 목록 조회 - 머구리 찾기

### DIFF
--- a/src/main/java/com/meoguri/linkocean/configuration/WebConfiguration.java
+++ b/src/main/java/com/meoguri/linkocean/configuration/WebConfiguration.java
@@ -12,6 +12,7 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 import com.meoguri.linkocean.configuration.security.oauth.LoginUserArgumentResolver;
 import com.meoguri.linkocean.controller.bookmark.support.GetBookmarkQueryParamsArgumentResolver;
+import com.meoguri.linkocean.controller.profile.support.GetProfileQueryParamsArgumentResolver;
 
 import lombok.RequiredArgsConstructor;
 
@@ -21,11 +22,13 @@ public class WebConfiguration implements WebMvcConfigurer {
 
 	private final LoginUserArgumentResolver loginUserArgumentResolver;
 	private final GetBookmarkQueryParamsArgumentResolver getBookmarkQueryParamsArgumentResolver;
+	private final GetProfileQueryParamsArgumentResolver getProfileQueryParamsArgumentResolver;
 
 	@Override
 	public void addArgumentResolvers(final List<HandlerMethodArgumentResolver> resolvers) {
 		resolvers.add(loginUserArgumentResolver);
 		resolvers.add(getBookmarkQueryParamsArgumentResolver);
+		resolvers.add(getProfileQueryParamsArgumentResolver);
 	}
 
 	@Override

--- a/src/main/java/com/meoguri/linkocean/controller/bookmark/BookmarkController.java
+++ b/src/main/java/com/meoguri/linkocean/controller/bookmark/BookmarkController.java
@@ -22,7 +22,7 @@ import com.meoguri.linkocean.controller.bookmark.dto.GetFeedBookmarksResponse;
 import com.meoguri.linkocean.controller.bookmark.dto.RegisterBookmarkRequest;
 import com.meoguri.linkocean.controller.bookmark.dto.UpdateBookmarkRequest;
 import com.meoguri.linkocean.controller.bookmark.support.GetBookmarkQueryParams;
-import com.meoguri.linkocean.controller.common.ListResponse;
+import com.meoguri.linkocean.controller.common.PageResponse;
 import com.meoguri.linkocean.controller.common.SimpleIdResponse;
 import com.meoguri.linkocean.domain.bookmark.service.BookmarkService;
 import com.meoguri.linkocean.domain.bookmark.service.dto.GetBookmarksResult;
@@ -53,7 +53,7 @@ public class BookmarkController {
 	 * - 내 북마크 목록 조회와 다른 사람 북마크 목록 조회로 나뉜다
 	 */
 	@GetMapping
-	public ListResponse<GetBookmarksResponse> getBookmarks(
+	public PageResponse<GetBookmarksResponse> getBookmarks(
 		final @LoginUser SessionUser user,
 		final GetBookmarkQueryParams queryParams
 	) {
@@ -64,7 +64,7 @@ public class BookmarkController {
 
 		final List<GetBookmarksResponse> response =
 			result.stream().map(GetBookmarksResponse::of).collect(toList());
-		return ListResponse.of("bookmarks", response);
+		return PageResponse.of("bookmarks", response);
 	}
 
 	/**
@@ -72,7 +72,7 @@ public class BookmarkController {
 	 * - 북마크 정보와 함께 작성자 프로필 정보를 반환한다
 	 */
 	@GetMapping("/feed")
-	public ListResponse<GetFeedBookmarksResponse> getFeedBookmarks(
+	public PageResponse<GetFeedBookmarksResponse> getFeedBookmarks(
 		final @LoginUser SessionUser user,
 		final @RequestBody GetBookmarkQueryParams queryParams
 	) {
@@ -80,7 +80,7 @@ public class BookmarkController {
 
 		final List<GetFeedBookmarksResponse> response =
 			result.stream().map(GetFeedBookmarksResponse::of).collect(toList());
-		return ListResponse.of("bookmarks", response);
+		return PageResponse.of("bookmarks", response);
 	}
 
 	/* 북마크 상세 조회 */

--- a/src/main/java/com/meoguri/linkocean/controller/bookmark/TagController.java
+++ b/src/main/java/com/meoguri/linkocean/controller/bookmark/TagController.java
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.RestController;
 import com.meoguri.linkocean.configuration.security.oauth.LoginUser;
 import com.meoguri.linkocean.configuration.security.oauth.SessionUser;
 import com.meoguri.linkocean.controller.bookmark.dto.GetMyTagsResponse;
-import com.meoguri.linkocean.controller.common.ListResponse;
+import com.meoguri.linkocean.controller.common.PageResponse;
 import com.meoguri.linkocean.domain.bookmark.service.TagService;
 
 import lombok.RequiredArgsConstructor;
@@ -24,12 +24,12 @@ public class TagController {
 	private final TagService tagService;
 
 	@GetMapping
-	public ListResponse<GetMyTagsResponse> getMyTags(@LoginUser SessionUser sessionUser) {
+	public PageResponse<GetMyTagsResponse> getMyTags(@LoginUser SessionUser sessionUser) {
 
 		final List<GetMyTagsResponse> tags = tagService.getMyTags(sessionUser.getId()).stream()
 			.map(GetMyTagsResponse::ofResult)
 			.collect(toList());
 
-		return ListResponse.of("tags", tags);
+		return PageResponse.of("tags", tags);
 	}
 }

--- a/src/main/java/com/meoguri/linkocean/controller/category/CategoryController.java
+++ b/src/main/java/com/meoguri/linkocean/controller/category/CategoryController.java
@@ -4,7 +4,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.meoguri.linkocean.controller.common.ListResponse;
+import com.meoguri.linkocean.controller.common.PageResponse;
 import com.meoguri.linkocean.domain.bookmark.service.CategoryService;
 
 import lombok.RequiredArgsConstructor;
@@ -17,8 +17,8 @@ public class CategoryController {
 	private final CategoryService categoryService;
 
 	@GetMapping
-	public ListResponse<String> getAllCategories() {
+	public PageResponse<String> getAllCategories() {
 
-		return ListResponse.of("categories", categoryService.getAllCategories());
+		return PageResponse.of("categories", categoryService.getAllCategories());
 	}
 }

--- a/src/main/java/com/meoguri/linkocean/controller/common/PageResponse.java
+++ b/src/main/java/com/meoguri/linkocean/controller/common/PageResponse.java
@@ -8,21 +8,21 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import lombok.Getter;
 
 @Getter
-@JsonSerialize(using = ListResponseJsonSerializer.class)
-public class ListResponse<T> {
+@JsonSerialize(using = PageResponseJsonSerializer.class)
+public class PageResponse<T> {
 
 	private final int count;
 	private final String name;
 	private final List<T> data;
 
-	public ListResponse(final String name, final List<T> data) {
+	public PageResponse(final String name, final List<T> data) {
 		this.count = data.size();
 		this.name = name;
 		this.data = data;
 	}
 
-	public static <T> ListResponse<T> of(final String name, final List<T> data) {
-		return new ListResponse<>(name, data);
+	public static <T> PageResponse<T> of(final String name, final List<T> data) {
+		return new PageResponse<>(name, data);
 	}
 
 	public List<Object> getData() {

--- a/src/main/java/com/meoguri/linkocean/controller/common/PageResponseJsonSerializer.java
+++ b/src/main/java/com/meoguri/linkocean/controller/common/PageResponseJsonSerializer.java
@@ -10,10 +10,10 @@ import com.fasterxml.jackson.databind.SerializerProvider;
  * 목록 조회의 공통 Serializer
  * - 데이터 타입 별로 array 의 이름을 커스터마이징 하기 위해 사용
  */
-public class ListResponseJsonSerializer extends JsonSerializer<ListResponse<?>> {
+public class PageResponseJsonSerializer extends JsonSerializer<PageResponse<?>> {
 
 	@Override
-	public void serialize(final ListResponse value, final JsonGenerator gen, final SerializerProvider serializers)
+	public void serialize(final PageResponse value, final JsonGenerator gen, final SerializerProvider serializers)
 		throws IOException {
 
 		gen.writeStartObject();

--- a/src/main/java/com/meoguri/linkocean/controller/common/SliceResponse.java
+++ b/src/main/java/com/meoguri/linkocean/controller/common/SliceResponse.java
@@ -1,0 +1,29 @@
+package com.meoguri.linkocean.controller.common;
+
+import java.util.Arrays;
+import java.util.List;
+
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
+import lombok.Getter;
+
+@Getter
+@JsonSerialize(using = SliceResponseJsonSerializer.class)
+public class SliceResponse<T> {
+
+	private final String name;
+	private final List<T> data;
+
+	public SliceResponse(final String name, final List<T> data) {
+		this.name = name;
+		this.data = data;
+	}
+
+	public static <T> SliceResponse<T> of(final String name, final List<T> data) {
+		return new SliceResponse<>(name, data);
+	}
+
+	public List<Object> getData() {
+		return Arrays.asList(data.toArray());
+	}
+}

--- a/src/main/java/com/meoguri/linkocean/controller/common/SliceResponseJsonSerializer.java
+++ b/src/main/java/com/meoguri/linkocean/controller/common/SliceResponseJsonSerializer.java
@@ -10,10 +10,10 @@ import com.fasterxml.jackson.databind.SerializerProvider;
  * 목록 조회의 공통 Serializer
  * - 데이터 타입 별로 array 의 이름을 커스터마이징 하기 위해 사용
  */
-public class SliceResponseJsonSerializer extends JsonSerializer<PageResponse<?>> {
+public class SliceResponseJsonSerializer extends JsonSerializer<SliceResponse<?>> {
 
 	@Override
-	public void serialize(final PageResponse value, final JsonGenerator gen, final SerializerProvider serializers)
+	public void serialize(final SliceResponse value, final JsonGenerator gen, final SerializerProvider serializers)
 		throws IOException {
 
 		gen.writeStartObject();

--- a/src/main/java/com/meoguri/linkocean/controller/common/SliceResponseJsonSerializer.java
+++ b/src/main/java/com/meoguri/linkocean/controller/common/SliceResponseJsonSerializer.java
@@ -1,0 +1,30 @@
+package com.meoguri.linkocean.controller.common;
+
+import java.io.IOException;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+
+/**
+ * 목록 조회의 공통 Serializer
+ * - 데이터 타입 별로 array 의 이름을 커스터마이징 하기 위해 사용
+ */
+public class SliceResponseJsonSerializer extends JsonSerializer<PageResponse<?>> {
+
+	@Override
+	public void serialize(final PageResponse value, final JsonGenerator gen, final SerializerProvider serializers)
+		throws IOException {
+
+		gen.writeStartObject();
+		gen.writeArrayFieldStart(value.getName());
+
+		for (Object datum : value.getData()) {
+			gen.writeObject(datum);
+		}
+
+		gen.writeEndArray();
+		gen.writeEndObject();
+	}
+
+}

--- a/src/main/java/com/meoguri/linkocean/controller/profile/dto/GetProfilesResponse.java
+++ b/src/main/java/com/meoguri/linkocean/controller/profile/dto/GetProfilesResponse.java
@@ -1,0 +1,30 @@
+package com.meoguri.linkocean.controller.profile.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.meoguri.linkocean.domain.profile.service.dto.SearchProfileResult;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class GetProfilesResponse {
+
+	private long id;
+	private String username;
+
+	@JsonProperty("imageUrl")
+	private String image;
+	private boolean isFollow;
+
+	public static GetProfilesResponse of(final SearchProfileResult result) {
+		return new GetProfilesResponse(
+			result.getId(),
+			result.getUsername(),
+			result.getImage(),
+			result.isFollow()
+		);
+	}
+}

--- a/src/main/java/com/meoguri/linkocean/controller/profile/dto/GetProfilesResponse.java
+++ b/src/main/java/com/meoguri/linkocean/controller/profile/dto/GetProfilesResponse.java
@@ -17,6 +17,8 @@ public class GetProfilesResponse {
 
 	@JsonProperty("imageUrl")
 	private String image;
+
+	@JsonProperty("isFollow")
 	private boolean isFollow;
 
 	public static GetProfilesResponse of(final SearchProfileResult result) {

--- a/src/main/java/com/meoguri/linkocean/controller/profile/dto/GetProfilesResponse.java
+++ b/src/main/java/com/meoguri/linkocean/controller/profile/dto/GetProfilesResponse.java
@@ -17,9 +17,7 @@ public class GetProfilesResponse {
 
 	@JsonProperty("imageUrl")
 	private String image;
-
-	@JsonProperty("isFollow")
-	private boolean isFollow;
+	private Boolean isFollow;
 
 	public static GetProfilesResponse of(final SearchProfileResult result) {
 		return new GetProfilesResponse(

--- a/src/main/java/com/meoguri/linkocean/controller/profile/support/GetProfileQueryParams.java
+++ b/src/main/java/com/meoguri/linkocean/controller/profile/support/GetProfileQueryParams.java
@@ -1,0 +1,11 @@
+package com.meoguri.linkocean.controller.profile.support;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public final class GetProfileQueryParams {
+
+	private final int page;
+	private final int size;
+	private final String username;
+}

--- a/src/main/java/com/meoguri/linkocean/controller/profile/support/GetProfileQueryParams.java
+++ b/src/main/java/com/meoguri/linkocean/controller/profile/support/GetProfileQueryParams.java
@@ -1,5 +1,7 @@
 package com.meoguri.linkocean.controller.profile.support;
 
+import com.meoguri.linkocean.domain.profile.service.dto.ProfileSearchCond;
+
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
@@ -8,4 +10,8 @@ public final class GetProfileQueryParams {
 	private final int page;
 	private final int size;
 	private final String username;
+
+	public ProfileSearchCond toSearchCond(final long userId) {
+		return new ProfileSearchCond(userId, page, size, username);
+	}
 }

--- a/src/main/java/com/meoguri/linkocean/controller/profile/support/GetProfileQueryParamsArgumentResolver.java
+++ b/src/main/java/com/meoguri/linkocean/controller/profile/support/GetProfileQueryParamsArgumentResolver.java
@@ -1,11 +1,6 @@
-package com.meoguri.linkocean.controller.bookmark.support;
+package com.meoguri.linkocean.controller.profile.support;
 
-import static org.apache.commons.lang3.BooleanUtils.*;
 import static org.apache.commons.lang3.math.NumberUtils.*;
-
-import java.util.Arrays;
-import java.util.Optional;
-import java.util.stream.Collectors;
 
 import org.springframework.core.MethodParameter;
 import org.springframework.stereotype.Component;
@@ -15,15 +10,14 @@ import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
 
 @Component
-public class GetBookmarkQueryParamsArgumentResolver implements HandlerMethodArgumentResolver {
+public class GetProfileQueryParamsArgumentResolver implements HandlerMethodArgumentResolver {
 
 	private static final int DEFAULT_PAGE = 1;
 	private static final int DEFAULT_SIZE = 8;
-	private static final String DEFAULT_ORDER = "upload";
 
 	@Override
 	public boolean supportsParameter(final MethodParameter parameter) {
-		return GetBookmarkQueryParams.class.isAssignableFrom(parameter.getParameterType());
+		return GetProfileQueryParams.class.isAssignableFrom(parameter.getParameterType());
 	}
 
 	@Override
@@ -32,24 +26,12 @@ public class GetBookmarkQueryParamsArgumentResolver implements HandlerMethodArgu
 
 		final String page = webRequest.getParameter("page");
 		final String size = webRequest.getParameter("size");
-		final String order = webRequest.getParameter("order");
-		final String category = webRequest.getParameter("category");
-		final String searchTitle = webRequest.getParameter("searchTitle");
 		final String username = webRequest.getParameter("username");
-		final String favorite = webRequest.getParameter("favorite");
-		final String follow = webRequest.getParameter("follow");
-		final String tags = webRequest.getParameter("tags");
 
-		return new GetBookmarkQueryParams(
+		return new GetProfileQueryParams(
 			toInt(page, DEFAULT_PAGE),
 			toInt(size, DEFAULT_SIZE),
-			Optional.ofNullable(order).orElse(DEFAULT_ORDER),
-			category,
-			searchTitle,
-			username,
-			toBoolean(favorite),
-			toBoolean(follow),
-			Arrays.stream(tags.split(",")).collect(Collectors.toList())
+			username
 		);
 	}
 }

--- a/src/main/java/com/meoguri/linkocean/domain/profile/service/ProfileServiceImpl.java
+++ b/src/main/java/com/meoguri/linkocean/domain/profile/service/ProfileServiceImpl.java
@@ -1,5 +1,6 @@
 package com.meoguri.linkocean.domain.profile.service;
 
+import static com.meoguri.linkocean.exception.Preconditions.*;
 import static java.util.stream.Collectors.*;
 
 import java.util.ArrayList;
@@ -136,6 +137,8 @@ public class ProfileServiceImpl implements ProfileService {
 
 	@Override
 	public List<SearchProfileResult> searchProfilesByUsername(final ProfileSearchCond searchCond) {
+		checkArgument(searchCond.getUsername() != null, "사용자 이름을 입력해 주세요");
+
 		final Long currentUserProfileId = findProfileByUserIdQuery.findByUserId(searchCond.getUserId()).getId();
 		List<Profile> profiles = profileRepository.findByUsernameLike(
 			new FindProfileCond(

--- a/src/test/java/com/meoguri/linkocean/controller/BaseControllerTest.java
+++ b/src/test/java/com/meoguri/linkocean/controller/BaseControllerTest.java
@@ -29,7 +29,9 @@ import com.meoguri.linkocean.configuration.security.oauth.SessionUser;
 import com.meoguri.linkocean.controller.bookmark.dto.RegisterBookmarkRequest;
 import com.meoguri.linkocean.controller.profile.dto.CreateProfileRequest;
 import com.meoguri.linkocean.controller.profile.dto.GetMyProfileResponse;
+import com.meoguri.linkocean.domain.user.entity.Email;
 import com.meoguri.linkocean.domain.user.entity.User;
+import com.meoguri.linkocean.domain.user.entity.User.OAuthType;
 import com.meoguri.linkocean.domain.user.repository.UserRepository;
 
 @AutoConfigureMockMvc
@@ -44,7 +46,7 @@ public class BaseControllerTest {
 	@Autowired
 	protected ObjectMapper objectMapper;
 
-	protected MockHttpSession session;
+	protected MockHttpSession session = new MockHttpSession();
 
 	@Autowired
 	private UserRepository userRepository;
@@ -52,8 +54,15 @@ public class BaseControllerTest {
 	protected void 유저_등록_로그인(final String email, final String oAuthType) {
 		final User savedUser = userRepository.save(new User(email, oAuthType));
 
-		session = new MockHttpSession();
 		session.setAttribute("user", new SessionUser(savedUser));
+	}
+
+	protected void 로그인(final String email, final String oAuthType) {
+		final User user = userRepository
+			.findByEmailAndOAuthType(new Email(email), OAuthType.valueOf(oAuthType))
+			.orElseThrow();
+
+		session.setAttribute("user", new SessionUser(user));
 	}
 
 	protected long 프로필_등록(final String username, final List<String> categories) throws Exception {

--- a/src/test/java/com/meoguri/linkocean/controller/BaseControllerTest.java
+++ b/src/test/java/com/meoguri/linkocean/controller/BaseControllerTest.java
@@ -67,7 +67,7 @@ public class BaseControllerTest {
 		return toId(mvcResult);
 	}
 
-	protected String 링크_메타데이터_조회(final String link) throws Exception {
+	protected String 링크_메타데이터_얻기(final String link) throws Exception {
 		mockMvc.perform(post(UriComponentsBuilder.fromUriString("/api/v1/linkmetadatas/obtain")
 				.queryParam("link", link)
 				.build()

--- a/src/test/java/com/meoguri/linkocean/controller/bookmark/BookmarkControllerTest.java
+++ b/src/test/java/com/meoguri/linkocean/controller/bookmark/BookmarkControllerTest.java
@@ -35,7 +35,7 @@ class BookmarkControllerTest extends BaseControllerTest {
 		//given
 		유저_등록_로그인("hani@gmail.com", "GOOGLE");
 		프로필_등록("hani", List.of("정치", "인문", "사회"));
-		final String link = 링크_메타데이터_조회("http://www.naver.com");
+		final String link = 링크_메타데이터_얻기("http://www.naver.com");
 
 		final String title = "title1";
 		final String memo = "memo";
@@ -62,7 +62,7 @@ class BookmarkControllerTest extends BaseControllerTest {
 		유저_등록_로그인("crush@gmail.com", "GOOGLE");
 		프로필_등록("crush", List.of("IT", "인문"));
 
-		링크_메타데이터_조회("http://www.naver.com");
+		링크_메타데이터_얻기("http://www.naver.com");
 
 		final Long userId = ((SessionUser)session.getAttribute("user")).getId();
 

--- a/src/test/java/com/meoguri/linkocean/controller/bookmark/ReactionControllerTest.java
+++ b/src/test/java/com/meoguri/linkocean/controller/bookmark/ReactionControllerTest.java
@@ -34,7 +34,8 @@ class ReactionControllerTest extends BaseControllerTest {
 
 		/* "bookmarkId" from bookmarkService */
 		final long savedBookmarkId = bookmarkService.registerBookmark(
-			new RegisterBookmarkCommand(userId, 링크_메타데이터_조회("http://www.naver.com"), "title", "memo", "인문", "all", List.of("tag1", "tag2"))
+			new RegisterBookmarkCommand(userId, 링크_메타데이터_얻기("http://www.naver.com"), "title", "memo", "인문", "all",
+				List.of("tag1", "tag2"))
 		);
 
 		//when

--- a/src/test/java/com/meoguri/linkocean/controller/category/CategoryControllerTest.java
+++ b/src/test/java/com/meoguri/linkocean/controller/category/CategoryControllerTest.java
@@ -9,13 +9,12 @@ import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
 
 import com.meoguri.linkocean.controller.BaseControllerTest;
-import com.meoguri.linkocean.domain.bookmark.entity.Bookmark.Category;
 
 class CategoryControllerTest extends BaseControllerTest {
 
 	private final String basePath = getBaseUrl(CategoryController.class);
 
-		@Test
+	@Test
 	void 카테고리_전체_조회_Api_성공() throws Exception {
 		//when
 		mockMvc.perform(get(basePath)
@@ -27,18 +26,8 @@ class CategoryControllerTest extends BaseControllerTest {
 				jsonPath("$.count").value(12),
 				jsonPath("$.categories").isArray(),
 				jsonPath("$.categories", hasSize(12)),
-				jsonPath("$.categories[0]").value(Category.getKoreanNames().get(0)),
-				jsonPath("$.categories[1]").value(Category.getKoreanNames().get(1)),
-				jsonPath("$.categories[2]").value(Category.getKoreanNames().get(2)),
-				jsonPath("$.categories[3]").value(Category.getKoreanNames().get(3)),
-				jsonPath("$.categories[4]").value(Category.getKoreanNames().get(4)),
-				jsonPath("$.categories[5]").value(Category.getKoreanNames().get(5)),
-				jsonPath("$.categories[6]").value(Category.getKoreanNames().get(6)),
-				jsonPath("$.categories[7]").value(Category.getKoreanNames().get(7)),
-				jsonPath("$.categories[8]").value(Category.getKoreanNames().get(8)),
-				jsonPath("$.categories[9]").value(Category.getKoreanNames().get(9)),
-				jsonPath("$.categories[10]").value(Category.getKoreanNames().get(10)),
-				jsonPath("$.categories[11]").value(Category.getKoreanNames().get(11))
+				jsonPath("$.categories",
+					hasItems("자기계발", "인문", "정치", "사회", "예술", "과학", "기술", "IT", "가정", "건강", "여행", "요리"))
 			).andDo(print());
 	}
 }

--- a/src/test/java/com/meoguri/linkocean/controller/profile/ProfileControllerTest.java
+++ b/src/test/java/com/meoguri/linkocean/controller/profile/ProfileControllerTest.java
@@ -1,20 +1,18 @@
 package com.meoguri.linkocean.controller.profile;
 
-import static org.assertj.core.api.Assertions.*;
 import static org.hamcrest.Matchers.*;
+import static org.springframework.http.MediaType.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import java.util.List;
 
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.springframework.http.MediaType;
-import org.springframework.mock.web.MockHttpServletResponse;
 
 import com.meoguri.linkocean.controller.BaseControllerTest;
 import com.meoguri.linkocean.controller.profile.dto.CreateProfileRequest;
-import com.meoguri.linkocean.controller.profile.dto.GetMyProfileResponse;
 
 class ProfileControllerTest extends BaseControllerTest {
 
@@ -24,17 +22,15 @@ class ProfileControllerTest extends BaseControllerTest {
 	void 프로필_등록_Api_성공() throws Exception {
 		//given
 		유저_등록_로그인("hani@gmail.com", "GOOGLE");
-
 		final String username = "hani";
 		final List<String> categories = List.of("인문", "정치", "사회");
-
 		final CreateProfileRequest createProfileRequest = new CreateProfileRequest(username, categories);
 
 		//when
-		mockMvc.perform(post(basePath).session(session)
-				.contentType(MediaType.APPLICATION_JSON)
+		mockMvc.perform(post(basePath)
+				.session(session)
+				.contentType(APPLICATION_JSON)
 				.content(createJson(createProfileRequest)))
-
 			//then
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.id").exists())
@@ -50,95 +46,93 @@ class ProfileControllerTest extends BaseControllerTest {
 	3. 팔로워, 팔로위 수
 	4. Bio, imageUrl
 	 */
-	@Test
-	void 내프로필_조회_단순_프로필_정보_조회() throws Exception {
-		//given
-		유저_등록_로그인("hani@gmail.com", "GOOGLE");
-		프로필_등록("hani", List.of("인문", "정치", "사회"));
+	@Nested
+	class 내_프로필_조회_테스트 {
 
-		//when
-		mockMvc.perform(get(basePath + "/me").session(session)
-				.contentType(MediaType.APPLICATION_JSON))
+		@Test
+		void 내프로필_조회_단순_프로필_정보_조회() throws Exception {
+			//given
+			유저_등록_로그인("hani@gmail.com", "GOOGLE");
+			프로필_등록("hani", List.of("인문", "정치", "사회"));
 
-			//then
-			.andExpect(status().isOk())
-			.andExpectAll(
-				jsonPath("$.profileId").exists(),
-				jsonPath("$.imageUrl").isEmpty(),
-				jsonPath("$.favoriteCategories", hasSize(3)),
-				jsonPath("$.username").value("hani"),
-				jsonPath("$.bio").isEmpty(),
-				jsonPath("$.followerCount").value(0),
-				jsonPath("$.followeeCount").value(0),
-				jsonPath("$.tags", hasSize(0)),
-				jsonPath("$.categories", hasSize(0))
+			//when
+			mockMvc.perform(get(basePath + "/me")
+					.session(session)
+					.contentType(APPLICATION_JSON))
+				//then
+				.andExpect(status().isOk())
+				.andExpectAll(
+					jsonPath("$.profileId").exists(),
+					jsonPath("$.imageUrl").isEmpty(),
+					jsonPath("$.favoriteCategories", hasSize(3)),
+					jsonPath("$.username").value("hani"),
+					jsonPath("$.bio").isEmpty(),
+					jsonPath("$.followerCount").value(0),
+					jsonPath("$.followeeCount").value(0),
+					jsonPath("$.tags", hasSize(0)),
+					jsonPath("$.categories", hasSize(0))
+				)
+				.andDo(print());
+		}
 
-			)
-			.andDo(print());
-	}
+		@Test
+		void 내프로필_조회_사용자가_작성한_카테고리_조회() throws Exception {
+			//given
+			유저_등록_로그인("hani@gmail.com", "GOOGLE");
+			프로필_등록("hani", List.of("인문", "정치", "사회", "IT"));
 
-	@Test
-	void 내프로필_조회_사용자가_작성한_카테고리_조회() throws Exception {
-		//given
-		유저_등록_로그인("hani@gmail.com", "GOOGLE");
-		프로필_등록("hani", List.of("인문", "정치", "사회", "IT"));
+			북마크_등록(링크_메타데이터_얻기("http://www.naver.com"), "인문", null, "private");
+			북마크_등록(링크_메타데이터_얻기("https://jojoldu.tistory.com"), "사회", null, "all");
+			북마크_등록(링크_메타데이터_얻기("https://github.com"), "IT", null, "private");
 
-		북마크_등록(링크_메타데이터_조회("http://www.naver.com"), "인문", null, "private");
-		북마크_등록(링크_메타데이터_조회("https://jojoldu.tistory.com"), "사회", null, "all");
-		북마크_등록(링크_메타데이터_조회("https://github.com"), "IT", null, "private");
+			//when
+			mockMvc.perform(get(basePath + "/me")
+					.session(session)
+					.contentType(APPLICATION_JSON))
+				//then
+				.andExpect(status().isOk())
+				.andExpectAll(
+					jsonPath("$.profileId").exists(),
+					jsonPath("$.imageUrl").isEmpty(),
+					jsonPath("$.favoriteCategories", hasSize(4)),
+					jsonPath("$.username").value("hani"),
+					jsonPath("$.bio").isEmpty(),
+					jsonPath("$.followerCount").value(0),
+					jsonPath("$.followeeCount").value(0),
+					jsonPath("$.tags", hasSize(0)),
+					jsonPath("$.categories", hasSize(3)),
+					jsonPath("$.categories[0]").value("인문"),
+					jsonPath("$.categories[1]").value("사회"),
+					jsonPath("$.categories[2]").value("IT"))
+				.andDo(print());
+		}
 
-		//when
-		final MockHttpServletResponse response = mockMvc.perform(get(basePath + "/me").session(session)
-				.contentType(MediaType.APPLICATION_JSON))
+		@Test
+		void 내프로필_조회_사용자가_작성한_카테고리_조회_카테고리가_null일때() throws Exception {
+			//given
+			유저_등록_로그인("hani@gmail.com", "GOOGLE");
+			프로필_등록("hani", List.of("인문", "정치", "사회", "IT"));
 
-			//then
-			.andExpect(status().isOk())
-			.andExpectAll(
-				jsonPath("$.profileId").exists(),
-				jsonPath("$.imageUrl").isEmpty(),
-				jsonPath("$.favoriteCategories", hasSize(4)),
-				jsonPath("$.username").value("hani"),
-				jsonPath("$.bio").isEmpty(),
-				jsonPath("$.followerCount").value(0),
-				jsonPath("$.followeeCount").value(0),
-				jsonPath("$.tags", hasSize(0)),
-				jsonPath("$.categories", hasSize(3))
-			)
-			.andDo(print())
-			.andReturn().getResponse();
+			북마크_등록(링크_메타데이터_얻기("http://www.naver.com"), null, null, "private");
 
-		final List<String> userCategories =
-			objectMapper.readValue(response.getContentAsByteArray(), GetMyProfileResponse.class).getCategories();
-
-		assertThat(userCategories).contains("인문", "사회", "IT");
-	}
-
-	@Test
-	void 내프로필_조회_사용자가_작성한_카테고리_조회_카테고리가_null일때() throws Exception {
-		//given
-		유저_등록_로그인("hani@gmail.com", "GOOGLE");
-		프로필_등록("hani", List.of("인문", "정치", "사회", "IT"));
-
-		북마크_등록(링크_메타데이터_조회("http://www.naver.com"), null, null, "private");
-
-		//when
-		final MockHttpServletResponse response = mockMvc.perform(get(basePath + "/me").session(session)
-				.contentType(MediaType.APPLICATION_JSON))
-
-			//then
-			.andExpect(status().isOk())
-			.andExpectAll(
-				jsonPath("$.profileId").exists(),
-				jsonPath("$.imageUrl").isEmpty(),
-				jsonPath("$.favoriteCategories", hasSize(4)),
-				jsonPath("$.username").value("hani"),
-				jsonPath("$.bio").isEmpty(),
-				jsonPath("$.followerCount").value(0),
-				jsonPath("$.followeeCount").value(0),
-				jsonPath("$.tags", hasSize(0)),
-				jsonPath("$.categories", hasSize(0))
-			)
-			.andDo(print())
-			.andReturn().getResponse();
+			//when
+			mockMvc.perform(get(basePath + "/me")
+					.session(session)
+					.contentType(APPLICATION_JSON))
+				//then
+				.andExpect(status().isOk())
+				.andExpectAll(
+					jsonPath("$.profileId").exists(),
+					jsonPath("$.imageUrl").isEmpty(),
+					jsonPath("$.favoriteCategories", hasSize(4)),
+					jsonPath("$.username").value("hani"),
+					jsonPath("$.bio").isEmpty(),
+					jsonPath("$.followerCount").value(0),
+					jsonPath("$.followeeCount").value(0),
+					jsonPath("$.tags", hasSize(0)),
+					jsonPath("$.categories", hasSize(0))
+				)
+				.andDo(print());
+		}
 	}
 }

--- a/src/test/java/com/meoguri/linkocean/controller/profile/ProfileControllerTest.java
+++ b/src/test/java/com/meoguri/linkocean/controller/profile/ProfileControllerTest.java
@@ -102,14 +102,12 @@ class ProfileControllerTest extends BaseControllerTest {
 					jsonPath("$.followeeCount").value(0),
 					jsonPath("$.tags", hasSize(0)),
 					jsonPath("$.categories", hasSize(3)),
-					jsonPath("$.categories[0]").value("인문"),
-					jsonPath("$.categories[1]").value("사회"),
-					jsonPath("$.categories[2]").value("IT"))
+					jsonPath("$.categories", hasItems("인문", "사회", "IT")))
 				.andDo(print());
 		}
 
 		@Test
-		void 내프로필_조회_사용자가_작성한_카테고리_조회_카테고리가_null일때() throws Exception {
+		void 내프로필_조회_사용자가_작성한_카테고리_조회_카테고리가_null_일때() throws Exception {
 			//given
 			유저_등록_로그인("hani@gmail.com", "GOOGLE");
 			프로필_등록("hani", List.of("인문", "정치", "사회", "IT"));

--- a/src/test/java/com/meoguri/linkocean/domain/profile/service/ProfileServiceImplTest.java
+++ b/src/test/java/com/meoguri/linkocean/domain/profile/service/ProfileServiceImplTest.java
@@ -287,6 +287,6 @@ class ProfileServiceImplTest {
 
 	static ProfileSearchCond defaultSearchCondOfUserId(long userId, String username) {
 
-		return new ProfileSearchCond(userId, null, null, null);
+		return new ProfileSearchCond(userId, null, null, username);
 	}
 }


### PR DESCRIPTION
## 🛠️ 작업 내용
- 프로필 목록 조회 - 머구리 찾기 컨트롤러

## 🗨️ 기타
- 기존 ListResponse 를 PageResponse 로 이름을 바꾸고 total count 가 필요 없는 페이지 (slice) 요청에 대한 array 를 wrapping 하는 SliceResponse 를 PageResponse 와 같은 방식으로 구현하였습니다.

- 목록 json 응답에 대해 hasItems 적용하면 좋을것 같습니다. 순서가 보장되지 않아도 적용 가능하네요