### PR TITLE
[LO-104] 북마크 상세 조회 컨트롤러 & 서비스 개발

### DIFF
--- a/src/main/java/com/meoguri/linkocean/controller/bookmark/dto/GetDetailedBookmarkResponse.java
+++ b/src/main/java/com/meoguri/linkocean/controller/bookmark/dto/GetDetailedBookmarkResponse.java
@@ -28,6 +28,7 @@ public final class GetDetailedBookmarkResponse {
 	private final LocalDate updatedAt;
 	private final List<String> tags;
 	private final Map<String, Long> reactionCount;
+	private final Map<String, Boolean> reaction;
 	private final GetBookmarkProfileResponse profile;
 
 	public static GetDetailedBookmarkResponse of(final GetDetailedBookmarkResult result) {
@@ -42,6 +43,7 @@ public final class GetDetailedBookmarkResponse {
 			result.getUpdatedAt().toLocalDate(),
 			result.getTags(),
 			result.getReactionCount(),
+			result.getReaction(),
 			GetBookmarkProfileResponse.of(result.getProfile())
 		);
 	}

--- a/src/main/java/com/meoguri/linkocean/domain/bookmark/service/dto/GetDetailedBookmarkResult.java
+++ b/src/main/java/com/meoguri/linkocean/domain/bookmark/service/dto/GetDetailedBookmarkResult.java
@@ -28,6 +28,7 @@ public final class GetDetailedBookmarkResult {
 	private List<String> tags;
 
 	private Map<String, Long> reactionCount;
+	private Map<String, Boolean> reaction;
 
 	private final GetBookmarkProfileResult profile;
 

--- a/src/test/java/com/meoguri/linkocean/controller/bookmark/BookmarkControllerTest.java
+++ b/src/test/java/com/meoguri/linkocean/controller/bookmark/BookmarkControllerTest.java
@@ -97,6 +97,8 @@ class BookmarkControllerTest extends BaseControllerTest {
 				jsonPath("$.tags[1]").value(savedBookmark.getTagNames().get(1)),
 				jsonPath("$.reactionCount.like").value(0),
 				jsonPath("$.reactionCount.hate").value(0),
+				jsonPath("$.reaction.like").value(false),
+				jsonPath("$.reaction.hate").value(false),
 				jsonPath("$.profile.profileId").value(savedBookmark.getProfile().getId()),
 				jsonPath("$.profile.username").value(savedBookmark.getProfile().getUsername()),
 				jsonPath("$.profile.imageUrl").value(savedBookmark.getProfile().getImage()),

--- a/src/test/java/com/meoguri/linkocean/domain/bookmark/service/BookmarkServiceImplTest.java
+++ b/src/test/java/com/meoguri/linkocean/domain/bookmark/service/BookmarkServiceImplTest.java
@@ -4,8 +4,10 @@ import static com.meoguri.linkocean.domain.bookmark.service.dto.GetDetailedBookm
 import static com.meoguri.linkocean.domain.util.Fixture.*;
 import static java.util.Collections.*;
 import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import javax.persistence.EntityManager;
@@ -19,8 +21,12 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.meoguri.linkocean.domain.bookmark.entity.Bookmark;
+import com.meoguri.linkocean.domain.bookmark.entity.Favorite;
+import com.meoguri.linkocean.domain.bookmark.entity.Reaction;
 import com.meoguri.linkocean.domain.bookmark.entity.Tag;
 import com.meoguri.linkocean.domain.bookmark.persistence.BookmarkRepository;
+import com.meoguri.linkocean.domain.bookmark.persistence.FavoriteRepository;
+import com.meoguri.linkocean.domain.bookmark.persistence.ReactionRepository;
 import com.meoguri.linkocean.domain.bookmark.persistence.TagRepository;
 import com.meoguri.linkocean.domain.bookmark.service.dto.GetDetailedBookmarkResult;
 import com.meoguri.linkocean.domain.bookmark.service.dto.RegisterBookmarkCommand;
@@ -54,6 +60,12 @@ class BookmarkServiceImplTest {
 
 	@Autowired
 	private TagRepository tagRepository;
+
+	@Autowired
+	private ReactionRepository reactionRepository;
+
+	@Autowired
+	private FavoriteRepository favoriteRepository;
 
 	@PersistenceContext
 	private EntityManager em;
@@ -250,72 +262,110 @@ class BookmarkServiceImplTest {
 		}
 	}
 
-	@Test
-	void 북마크_상세_조회_성공() {
-		//given
-		final Bookmark bookmark = Bookmark.builder()
-			.profile(profile)
-			.title("title")
-			.linkMetadata(linkMetadata)
-			.memo("dream company")
-			.category("인문")
-			.openType("all")
-			.url("www.google.com")
-			.build();
+	@Nested
+	class 북마크_상세_조회_테스트 {
 
-		final Tag tag = tagRepository.save(new Tag("tag1"));
-		bookmark.addBookmarkTag(tag);
+		private Bookmark bookmark;
 
-		final Bookmark savedBookmark = bookmarkRepository.save(bookmark);
+		@BeforeEach
+		void setUp() {
+			bookmark = Bookmark.builder()
+				.profile(profile)
+				.title("title")
+				.linkMetadata(linkMetadata)
+				.memo("dream company")
+				.category("인문")
+				.openType("all")
+				.url("www.google.com")
+				.build();
 
-		em.flush();
-		em.clear();
+			final Tag tag = tagRepository.save(new Tag("tag1"));
+			bookmark.addBookmarkTag(tag);
 
-		//when
-		final GetDetailedBookmarkResult result = bookmarkService.getDetailedBookmark(userId, savedBookmark.getId());
+			final Bookmark savedBookmark = bookmarkRepository.save(bookmark);
 
-		//then
-		assertThat(result).extracting(
-			GetDetailedBookmarkResult::getTitle,
-			GetDetailedBookmarkResult::getUrl,
-			GetDetailedBookmarkResult::getImage,
-			GetDetailedBookmarkResult::getCategory,
-			GetDetailedBookmarkResult::getMemo,
-			GetDetailedBookmarkResult::getOpenType,
-			GetDetailedBookmarkResult::isFavorite,
-			GetDetailedBookmarkResult::getUpdatedAt
-		).containsExactly(
-			savedBookmark.getTitle(),
-			savedBookmark.getLinkMetadata().getLink().getFullLink(),
-			savedBookmark.getLinkMetadata().getImage(),
-			savedBookmark.getCategory(),
-			savedBookmark.getMemo(),
-			savedBookmark.getOpenType(),
-			false,
-			savedBookmark.getUpdatedAt()
-		);
-		assertThat(result.getTags())
-			.contains("tag1");
+			em.flush();
+			em.clear();
+		}
 
-		assertThat(result.getReactionCount().get("like")).isZero();
-		assertThat(result.getReactionCount().get("hate")).isZero();
+		@Test
+		void 북마크_상세_조회_성공() {
+			//when
+			final GetDetailedBookmarkResult result = bookmarkService.getDetailedBookmark(userId, bookmark.getId());
 
-		assertThat(result.getProfile())
-			.extracting(
-				GetBookmarkProfileResult::getProfileId,
-				GetBookmarkProfileResult::getUsername,
-				GetBookmarkProfileResult::getImage,
-				GetBookmarkProfileResult::isFollow
-			).containsExactly(profile.getId(), profile.getUsername(), profile.getImage(), false);
-	}
+			//then
+			assertThat(result).extracting(
+				GetDetailedBookmarkResult::getTitle,
+				GetDetailedBookmarkResult::getUrl,
+				GetDetailedBookmarkResult::getImage,
+				GetDetailedBookmarkResult::getCategory,
+				GetDetailedBookmarkResult::getMemo,
+				GetDetailedBookmarkResult::getOpenType,
+				GetDetailedBookmarkResult::isFavorite,
+				GetDetailedBookmarkResult::getUpdatedAt
+			).containsExactly(
+				bookmark.getTitle(),
+				bookmark.getLinkMetadata().getLink().getFullLink(),
+				bookmark.getLinkMetadata().getImage(),
+				bookmark.getCategory(),
+				bookmark.getMemo(),
+				bookmark.getOpenType(),
+				false,
+				bookmark.getUpdatedAt()
+			);
+			assertThat(result.getTags())
+				.contains("tag1");
 
-	@Test
-	void 북마크_조회_실패_존재하지_않는_북마크() {
-		//given
-		final long invalidBookmarkId = 10L;
+			assertThat(result.getReactionCount().get("like")).isZero();
+			assertThat(result.getReactionCount().get("hate")).isZero();
 
-		//when then
-		assertThatExceptionOfType(LinkoceanRuntimeException.class)
-			.isThrownBy(() -> bookmarkService.getDetailedBookmark(userId, invalidBookmarkId));
+			assertThat(result.getReaction().get("like")).isFalse();
+			assertThat(result.getReaction().get("hate")).isFalse();
+
+			assertThat(result.getProfile())
+				.extracting(
+					GetBookmarkProfileResult::getProfileId,
+					GetBookmarkProfileResult::getUsername,
+					GetBookmarkProfileResult::getImage,
+					GetBookmarkProfileResult::isFollow
+				).containsExactly(profile.getId(), profile.getUsername(), profile.getImage(), false);
+		}
+
+		@Test
+		void 내가_좋아요_누른_북마크_상세_조회_성공() {
+			//given
+			reactionRepository.save(new Reaction(profile, bookmark, "like"));
+
+			//when
+			final GetDetailedBookmarkResult result = bookmarkService.getDetailedBookmark(userId, bookmark.getId());
+
+			//then
+			assertAll(
+				() -> assertThat(result.getReactionCount()).containsExactlyEntriesOf(Map.of("like", 1L, "hate", 0L)),
+				() -> assertThat(result.getReaction()).containsExactlyEntriesOf(Map.of("like", true, "hate", false))
+			);
+		}
+
+		@Test
+		void 내가_즐겨찾기한_북마크_상세_조회_성공() {
+			//given
+			favoriteRepository.save(new Favorite(bookmark, profile));
+
+			//when
+			final GetDetailedBookmarkResult result = bookmarkService.getDetailedBookmark(userId, bookmark.getId());
+
+			//then
+			assertThat(result.isFavorite()).isTrue();
+		}
+
+		@Test
+		void 북마크_조회_실패_존재하지_않는_북마크() {
+			//given
+			final long invalidBookmarkId = 10L;
+
+			//when then
+			assertThatExceptionOfType(LinkoceanRuntimeException.class)
+				.isThrownBy(() -> bookmarkService.getDetailedBookmark(userId, invalidBookmarkId));
+		}
 	}
 }

--- a/src/test/java/com/meoguri/linkocean/domain/bookmark/service/BookmarkServiceImplTest.java
+++ b/src/test/java/com/meoguri/linkocean/domain/bookmark/service/BookmarkServiceImplTest.java
@@ -341,8 +341,10 @@ class BookmarkServiceImplTest {
 
 			//then
 			assertAll(
-				() -> assertThat(result.getReactionCount()).containsExactlyEntriesOf(Map.of("like", 1L, "hate", 0L)),
-				() -> assertThat(result.getReaction()).containsExactlyEntriesOf(Map.of("like", true, "hate", false))
+				() -> assertThat(result.getReactionCount())
+					.containsExactlyInAnyOrderEntriesOf(Map.of("like", 1L, "hate", 0L)),
+				() -> assertThat(result.getReaction())
+					.containsExactlyInAnyOrderEntriesOf(Map.of("like", true, "hate", false))
 			);
 		}
 


### PR DESCRIPTION
## 🛠️ 작업 내용
- 북마크 상세 조회 컨트롤러 & 서비스 개발

## 🗨️ 기타
<!-- PR 포인트 혹은 궁금한 점 등등 적어주시면 됩니다. 없으시면 지워주세요 -->
- 북마크 상세 조회 `API`에 내려줘야 하는 데이터가 추가돼 컨트롤러와 서비스를 수정했습니다.
- 북마크 상세 조회에서 북마크 좋아요 개수를 가져와야하는데 아직은 `count` 쿼리를 이용합니다. (추후 리액션 요청의 수정사항이 생기면 수정하겠습니다.)

## 😎 리뷰어
@ndy2 , @jk05018 , @NewEgoDoc
