### PR TITLE
[LO-67] 공유 알림 생성, 알림 목록 조회 컨트롤러 

### DIFF
--- a/src/main/java/com/meoguri/linkocean/controller/notification/NotificationController.java
+++ b/src/main/java/com/meoguri/linkocean/controller/notification/NotificationController.java
@@ -34,6 +34,7 @@ public class NotificationController {
 	}
 
 	/* 알림 조회 */
+	// 개발 속도 및 적절한 방법을 모르는 고려하여 그냥 Entity 를 반환함 추후 학습하여 리팩토링
 	@GetMapping
 	public SliceResponse<Notification> getNotifications(
 		final @LoginUser SessionUser user

--- a/src/main/java/com/meoguri/linkocean/controller/notification/NotificationController.java
+++ b/src/main/java/com/meoguri/linkocean/controller/notification/NotificationController.java
@@ -1,0 +1,44 @@
+package com.meoguri.linkocean.controller.notification;
+
+import java.util.List;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.meoguri.linkocean.configuration.security.oauth.LoginUser;
+import com.meoguri.linkocean.configuration.security.oauth.SessionUser;
+import com.meoguri.linkocean.controller.common.SliceResponse;
+import com.meoguri.linkocean.controller.notification.dto.ShareNotificationRequest;
+import com.meoguri.linkocean.domain.notification.entity.Notification;
+import com.meoguri.linkocean.domain.notification.service.NotificationService;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/notifications")
+@RestController
+public class NotificationController {
+
+	private final NotificationService notificationService;
+
+	/* 공유 알림 생성 */
+	@PostMapping
+	public void shareNotification(
+		final @LoginUser SessionUser user,
+		final @RequestBody ShareNotificationRequest request
+	) {
+		notificationService.shareNotification(request.toCommand(user.getId()));
+	}
+
+	/* 알림 조회 */
+	@GetMapping
+	public SliceResponse<Notification> getNotifications(
+		final @LoginUser SessionUser user
+	) {
+		final List<Notification> notifications = notificationService.getNotifications(user.getId());
+		return SliceResponse.of("notifications", notifications);
+	}
+}

--- a/src/main/java/com/meoguri/linkocean/controller/notification/dto/ShareNotificationRequest.java
+++ b/src/main/java/com/meoguri/linkocean/controller/notification/dto/ShareNotificationRequest.java
@@ -1,0 +1,21 @@
+package com.meoguri.linkocean.controller.notification.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.meoguri.linkocean.domain.notification.service.dto.ShareNotificationCommand;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public final class ShareNotificationRequest {
+
+	@JsonProperty("targetId")
+	private long targetProfileId;
+
+	private long bookmarkId;
+
+	public ShareNotificationCommand toCommand(long senderUserId) {
+		return new ShareNotificationCommand(senderUserId, targetProfileId, bookmarkId);
+	}
+}

--- a/src/main/java/com/meoguri/linkocean/domain/bookmark/entity/Bookmark.java
+++ b/src/main/java/com/meoguri/linkocean/domain/bookmark/entity/Bookmark.java
@@ -151,6 +151,10 @@ public class Bookmark extends BaseIdEntity {
 		return openType.getName();
 	}
 
+	public boolean isOwnedBy(final Profile profile) {
+		return this.profile.equals(profile);
+	}
+
 	/**
 	 * 북마크의 공개 범위
 	 */

--- a/src/main/java/com/meoguri/linkocean/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/meoguri/linkocean/domain/notification/service/NotificationService.java
@@ -7,6 +7,11 @@ import com.meoguri.linkocean.domain.notification.service.dto.ShareNotificationCo
 
 public interface NotificationService {
 
+	/**
+	 * 북마크 공유 알림 생성
+	 * - 나를 팔로우 해주는 상대에게만 공유 할 수 있다.
+	 * - 자신의 북마크만 공유할 수 있다.
+	 */
 	void shareNotification(ShareNotificationCommand command);
 
 	List<Notification> getNotifications(long userId);

--- a/src/main/java/com/meoguri/linkocean/domain/notification/service/NotificationServiceImpl.java
+++ b/src/main/java/com/meoguri/linkocean/domain/notification/service/NotificationServiceImpl.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.meoguri.linkocean.domain.bookmark.entity.Bookmark;
 import com.meoguri.linkocean.domain.bookmark.persistence.FindBookmarkByIdQuery;
@@ -24,6 +25,7 @@ import com.meoguri.linkocean.domain.profile.persistence.FindProfileByUserIdQuery
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 @Service
 public class NotificationServiceImpl implements NotificationService {
 
@@ -41,11 +43,12 @@ public class NotificationServiceImpl implements NotificationService {
 
 		final Profile sender = findProfileByUserIdQuery.findByUserId(senderUserId);
 		final Profile target = findProfileByIdQuery.findById(targetProfileId);
-		final boolean isSharable = checkIsFollowQuery.isFollow(target, sender);
+		final Bookmark bookmark = findBookmarkByIdQuery.findById(command.getBookmarkId());
 
+		final boolean isSharable =
+			checkIsFollowQuery.isFollow(target, sender) && bookmark.isOwnedBy(sender);
 		checkCondition(isSharable);
 
-		final Bookmark bookmark = findBookmarkByIdQuery.findById(command.getBookmarkId());
 		Map<String, Noti> info = Map.of(
 			"sender", new ProfileNoti(sender.getId(), sender.getUsername()),
 			"bookmark", new BookmarkNoti(bookmark.getId(), bookmark.getTitle(), bookmark.getUrl())

--- a/src/test/java/com/meoguri/linkocean/controller/notification/NotificationControllerTest.java
+++ b/src/test/java/com/meoguri/linkocean/controller/notification/NotificationControllerTest.java
@@ -1,0 +1,109 @@
+package com.meoguri.linkocean.controller.notification;
+
+import static java.util.Collections.*;
+import static org.hamcrest.Matchers.*;
+import static org.springframework.http.MediaType.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.meoguri.linkocean.controller.BaseControllerTest;
+import com.meoguri.linkocean.controller.notification.dto.ShareNotificationRequest;
+
+class NotificationControllerTest extends BaseControllerTest {
+
+	private final String baseUrl = getBaseUrl(NotificationController.class);
+
+	private long senderProfileId;
+	private long shareBookmarkId;
+	private long targetProfileId;
+	private long unsharableBookmarkId;
+
+	@BeforeEach
+	void setUp() throws Exception {
+		유저_등록_로그인("sender@gmail.com", "GOOGLE");
+		senderProfileId = 프로필_등록("sender", List.of("IT"));
+		shareBookmarkId = 북마크_등록(링크_메타데이터_얻기("http://www.naver.com"), null, emptyList(), "all");
+
+		유저_등록_로그인("target@gmail.com", "GOOGLE");
+		targetProfileId = 프로필_등록("target", List.of("IT"));
+		unsharableBookmarkId = 북마크_등록(링크_메타데이터_얻기("http://www.naver.com"), null, emptyList(), "all");
+		팔로우(senderProfileId);
+
+	}
+
+	@Test
+	void 공유_알림_생성하고_조회_성공() throws Exception {
+		//given
+		로그인("sender@gmail.com", "GOOGLE");
+		final ShareNotificationRequest request = new ShareNotificationRequest(targetProfileId, shareBookmarkId);
+
+		//when
+		//공유 알림 하나 생성
+		mockMvc.perform(post(baseUrl)
+				.session(session)
+				.contentType(APPLICATION_JSON)
+				.content(createJson(request)))
+			//then
+			.andExpect(status().isOk())
+			.andDo(print());
+
+		//when
+		//공유 알림 조회
+		로그인("target@gmail.com", "GOOGLE");
+		mockMvc.perform(get(baseUrl)
+				.session(session)
+				.contentType(APPLICATION_JSON))
+			//then
+			.andExpect(status().isOk())
+			.andExpectAll(
+				jsonPath("$.notifications", hasSize(1)),
+				jsonPath("$.notifications[0].info").exists(),
+
+				jsonPath("$.notifications[0].info.sender").exists(),
+				jsonPath("$.notifications[0].info.sender.profileId").value(senderProfileId),
+				jsonPath("$.notifications[0].info.sender.profileUsername").value("sender"),
+
+				jsonPath("$.notifications[0].info.bookmark").exists(),
+				jsonPath("$.notifications[0].info.bookmark.bookmarkId").value(shareBookmarkId),
+				jsonPath("$.notifications[0].info.bookmark.title").value("title"),
+				jsonPath("$.notifications[0].info.bookmark.url").value("http://www.naver.com")
+			)
+			.andDo(print());
+	}
+
+	@Test
+	void 대상이_나를_팔로우_중이_아니라면_공유_알림_추가_실패() throws Exception {
+		//given
+		로그인("target@gmail.com", "GOOGLE");
+		final ShareNotificationRequest request = new ShareNotificationRequest(senderProfileId, unsharableBookmarkId);
+
+		//when
+		mockMvc.perform(post(baseUrl)
+				.session(session)
+				.contentType(APPLICATION_JSON)
+				.content(createJson(request)))
+			//then
+			.andExpect(status().isBadRequest());
+	}
+
+	@Test
+	void 남의글_공유_알림_생성_요청_실패() throws Exception {
+		//given
+		로그인("sender@gmail.com", "GOOGLE");
+		final ShareNotificationRequest request = new ShareNotificationRequest(targetProfileId, unsharableBookmarkId);
+
+		//when
+		mockMvc.perform(post(baseUrl)
+				.session(session)
+				.contentType(APPLICATION_JSON)
+				.content(createJson(request)))
+			//then
+			.andExpect(status().isBadRequest());
+	}
+}

--- a/src/test/java/com/meoguri/linkocean/domain/notification/service/NotificationServiceImplTest.java
+++ b/src/test/java/com/meoguri/linkocean/domain/notification/service/NotificationServiceImplTest.java
@@ -122,4 +122,18 @@ class NotificationServiceImplTest {
 		assertThatExceptionOfType(LinkoceanRuntimeException.class)
 			.isThrownBy(() -> notificationService.shareNotification(command));
 	}
+
+	@Test
+	void 내_글이_아니면_공유_알림_추가_실패() {
+		//given - sender 가 target 사용자의 게시글을 공유하는 Illegal 한 커맨드
+		final ShareNotificationCommand command = new ShareNotificationCommand(
+			sender.getId(),
+			targetProfile.getId(),
+			notSharableBookmark.getId()
+		);
+
+		//when then
+		assertThatExceptionOfType(LinkoceanRuntimeException.class)
+			.isThrownBy(() -> notificationService.shareNotification(command));
+	}
 }


### PR DESCRIPTION
## 🛠️ 작업 내용
- 컨트롤러에서도 서비스에서처럼 일단은 엔티티를 반환하는 방식으로 구현했고 의도한 대로 동작은 하는데
   ObjectId 로 선언된 불필요한 정보들이 함께 나가고 Json 필드의 값을 맞추기 위해서 Jackson 의 어노테이션들이 도메인 영역까지 침투하는 문제가 생길거 같네요...
  일단은 이렇게 구현하였습니다.
- 서비스에서 공유 알림 생성시 남의 게시글에 대해서 막는 검증이 빠져있어서 추가하였습니다.

## 🗨️ 기타
- 일단은 mongoDB docker 로 진행하고 차차 api 가 하나씩 완성되고 여유가 되면 aws document db 로 옮겨보겠습니다.