### PR TITLE
[LO-118] joinIf 강화, 북마크 조회 통합 초벌

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,24 @@
 # Team-Meoguri-Linkocean-BE
 
-workflow trigger test
+## 용례
+
+### Ultimate (궁극의) <br>
+
+북마크, 프로필 필터링 조회 로직을 통합 하는 과정에서 등장한 모든것을 포괄한다는 의미를 담은 Prefix 리팩터링 이후에는 Ultimate 글자를 제거한다.
+
+예를 들어 `UltimateBookmarkFindCond` 는
+
+- `BookmarkFindCond`,
+- `FeedBookmarksSearchCond`,
+- `MyBookmarkSearchCond`,
+- `OtherBookmarksSearchCond`
+  를 모두 통합하는 역할을 한다.
+
+`ultimateFindBookmarks` 는
+
+- `findByCategory`
+- `findFavoriteBookmarks`
+- `findByTags`
+- `findBookmarks`
+  를 모두 통합하는 역할을 한다.
+  

--- a/src/main/java/com/meoguri/linkocean/domain/bookmark/persistence/CustomBookmarkRepository.java
+++ b/src/main/java/com/meoguri/linkocean/domain/bookmark/persistence/CustomBookmarkRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.domain.Pageable;
 
 import com.meoguri.linkocean.domain.bookmark.entity.Bookmark;
 import com.meoguri.linkocean.domain.bookmark.persistence.dto.BookmarkFindCond;
+import com.meoguri.linkocean.domain.bookmark.persistence.dto.UltimateBookmarkFindCond;
 
 public interface CustomBookmarkRepository {
 
@@ -23,4 +24,7 @@ public interface CustomBookmarkRepository {
 
 	/* 기본 조회 */
 	Page<Bookmark> findBookmarks(final BookmarkFindCond findCond, Pageable pageable);
+
+	/* 북마크 조회 */
+	Page<Bookmark> ultimateFindBookmarks(UltimateBookmarkFindCond findCond, Pageable pageable);
 }

--- a/src/main/java/com/meoguri/linkocean/domain/bookmark/persistence/CustomBookmarkRepositoryImpl.java
+++ b/src/main/java/com/meoguri/linkocean/domain/bookmark/persistence/CustomBookmarkRepositoryImpl.java
@@ -14,6 +14,7 @@ import org.springframework.stereotype.Repository;
 
 import com.meoguri.linkocean.domain.bookmark.entity.Bookmark;
 import com.meoguri.linkocean.domain.bookmark.persistence.dto.BookmarkFindCond;
+import com.meoguri.linkocean.domain.bookmark.persistence.dto.UltimateBookmarkFindCond;
 import com.meoguri.linkocean.util.Querydsl4RepositorySupport;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.dsl.BooleanExpression;
@@ -122,6 +123,13 @@ public class CustomBookmarkRepositoryImpl extends Querydsl4RepositorySupport imp
 				),
 			Bookmark::getTagNames
 		);
+	}
+
+	//TODO 궁극의 북마크 조회 구현
+	@Override
+	public Page<Bookmark> ultimateFindBookmarks(final UltimateBookmarkFindCond findCond, final Pageable pageable) {
+
+		return null;
 	}
 
 	private BooleanExpression profileIdEq(final long profileId) {

--- a/src/main/java/com/meoguri/linkocean/domain/bookmark/persistence/dto/UltimateBookmarkFindCond.java
+++ b/src/main/java/com/meoguri/linkocean/domain/bookmark/persistence/dto/UltimateBookmarkFindCond.java
@@ -1,0 +1,45 @@
+package com.meoguri.linkocean.domain.bookmark.persistence.dto;
+
+import java.util.List;
+
+import com.meoguri.linkocean.domain.bookmark.entity.Bookmark;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * <pre>
+ * 궁극의 북마크 조회 조건
+ * - `BookmarkFindCond`,
+ * - `FeedBookmarksSearchCond`,
+ * - `MyBookmarkSearchCond`,
+ * - `OtherBookmarksSearchCond` 를 통합 할 조건이다
+ * </pre>
+ */
+@Getter
+@RequiredArgsConstructor
+public final class UltimateBookmarkFindCond {
+
+	/* 현재 사용자의 프로필 id */
+	private final long currentUserProfileId;
+
+	/*작성자를 지정한 북마크 조회인 경우 대상 프로필 id
+	 만약 피드 페이지 조회 등의 작성자가 다양한 조회의 경우 null*/
+	private final Long targetProfileId;
+
+	/* 카테고리 필터링 조회인 경우 카테고리 아니라면 null */
+	private final Bookmark.Category category;
+
+	/* 즐겨찾기 필터링 조회인 경우 true 아니라면 false */
+	private final boolean favorite;
+
+	/* 태그 필터링 조회인 경우 태그 목록 아니라면 null */
+	private final List<String> tags;
+
+	/* 현재 사용자가 팔로우 하는 사용자대상 북마크의 필터링 여부
+	   피드 북마크 조회에 대해서만 참이 될 수 있다 */
+	private final boolean follow;
+
+	/* 제목 검색 조건 - contains 로 판별한다 */
+	private final String title;
+}

--- a/src/main/java/com/meoguri/linkocean/domain/profile/persistence/CustomProfileRepositoryImpl.java
+++ b/src/main/java/com/meoguri/linkocean/domain/profile/persistence/CustomProfileRepositoryImpl.java
@@ -2,7 +2,7 @@ package com.meoguri.linkocean.domain.profile.persistence;
 
 import static com.meoguri.linkocean.domain.profile.entity.QFollow.*;
 import static com.meoguri.linkocean.domain.profile.entity.QProfile.*;
-import static com.meoguri.linkocean.util.JoinInfoListBuilder.JoinInfoListBuilderInitializer.*;
+import static com.meoguri.linkocean.util.JoinInfoListBuilder.Initializer.*;
 import static com.meoguri.linkocean.util.QueryDslUtil.*;
 
 import java.util.List;

--- a/src/main/java/com/meoguri/linkocean/domain/profile/persistence/CustomProfileRepositoryImpl.java
+++ b/src/main/java/com/meoguri/linkocean/domain/profile/persistence/CustomProfileRepositoryImpl.java
@@ -2,6 +2,7 @@ package com.meoguri.linkocean.domain.profile.persistence;
 
 import static com.meoguri.linkocean.domain.profile.entity.QFollow.*;
 import static com.meoguri.linkocean.domain.profile.entity.QProfile.*;
+import static com.meoguri.linkocean.util.JoinInfoListBuilder.*;
 import static com.meoguri.linkocean.util.QueryDslUtil.*;
 
 import java.util.List;
@@ -68,7 +69,7 @@ public class CustomProfileRepositoryImpl implements CustomProfileRepository {
 			joinIf(query
 					.select(follow.follower)
 					.from(follow),
-				join(follow.follower, profile),
+				builder().join(follow.follower, profile).build(),
 				on(follow.follower.id.eq(profile.id)),
 				when(username != null)
 			).where(
@@ -84,7 +85,7 @@ public class CustomProfileRepositoryImpl implements CustomProfileRepository {
 			joinIf(query
 					.select(follow.followee)
 					.from(follow),
-				join(follow.followee, profile),
+				builder().join(follow.followee, profile).build(),
 				on(follow.followee.id.eq(profile.id)),
 				when(username != null)
 			).where(

--- a/src/main/java/com/meoguri/linkocean/domain/profile/persistence/CustomProfileRepositoryImpl.java
+++ b/src/main/java/com/meoguri/linkocean/domain/profile/persistence/CustomProfileRepositoryImpl.java
@@ -2,7 +2,7 @@ package com.meoguri.linkocean.domain.profile.persistence;
 
 import static com.meoguri.linkocean.domain.profile.entity.QFollow.*;
 import static com.meoguri.linkocean.domain.profile.entity.QProfile.*;
-import static com.meoguri.linkocean.util.JoinInfoListBuilder.*;
+import static com.meoguri.linkocean.util.JoinInfoListBuilder.JoinInfoListBuilderInitializer.*;
 import static com.meoguri.linkocean.util.QueryDslUtil.*;
 
 import java.util.List;
@@ -69,7 +69,7 @@ public class CustomProfileRepositoryImpl implements CustomProfileRepository {
 			joinIf(query
 					.select(follow.follower)
 					.from(follow),
-				builder().join(follow.follower, profile).build(),
+				join(follow.follower, profile),
 				on(follow.follower.id.eq(profile.id)),
 				when(username != null)
 			).where(
@@ -85,7 +85,7 @@ public class CustomProfileRepositoryImpl implements CustomProfileRepository {
 			joinIf(query
 					.select(follow.followee)
 					.from(follow),
-				builder().join(follow.followee, profile).build(),
+				join(follow.followee, profile),
 				on(follow.followee.id.eq(profile.id)),
 				when(username != null)
 			).where(

--- a/src/main/java/com/meoguri/linkocean/domain/profile/persistence/CustomProfileRepositoryImpl.java
+++ b/src/main/java/com/meoguri/linkocean/domain/profile/persistence/CustomProfileRepositoryImpl.java
@@ -69,7 +69,7 @@ public class CustomProfileRepositoryImpl implements CustomProfileRepository {
 			joinIf(query
 					.select(follow.follower)
 					.from(follow),
-				join(follow.follower, profile),
+				() -> join(follow.follower, profile),
 				on(follow.follower.id.eq(profile.id)),
 				when(username != null)
 			).where(
@@ -85,7 +85,7 @@ public class CustomProfileRepositoryImpl implements CustomProfileRepository {
 			joinIf(query
 					.select(follow.followee)
 					.from(follow),
-				join(follow.followee, profile),
+				() -> join(follow.followee, profile),
 				on(follow.followee.id.eq(profile.id)),
 				when(username != null)
 			).where(

--- a/src/main/java/com/meoguri/linkocean/util/JoinInfo.java
+++ b/src/main/java/com/meoguri/linkocean/util/JoinInfo.java
@@ -5,6 +5,10 @@ import com.querydsl.core.types.EntityPath;
 import com.querydsl.core.types.MapExpression;
 import com.querydsl.core.types.Path;
 
+/**
+ * JPAQueryBase의 join의 파라미터 정보를 담는 클래스
+ * @see com.querydsl.jpa.JPAQueryBase
+ */
 public class JoinInfo {
 
 	EntityPath targetEntityPath;

--- a/src/main/java/com/meoguri/linkocean/util/JoinInfo.java
+++ b/src/main/java/com/meoguri/linkocean/util/JoinInfo.java
@@ -1,0 +1,55 @@
+package com.meoguri.linkocean.util;
+
+import com.querydsl.core.types.CollectionExpression;
+import com.querydsl.core.types.EntityPath;
+import com.querydsl.core.types.MapExpression;
+import com.querydsl.core.types.Path;
+
+public class JoinInfo {
+
+	EntityPath targetEntityPath;
+
+	CollectionExpression targetCollection;
+
+	MapExpression targetMap;
+
+	Path alias;
+
+	boolean isFetchJoin;
+
+	int joinType;
+
+	public JoinInfo(EntityPath target) {
+		this.targetEntityPath = target;
+		this.joinType = 1;
+	}
+
+	public JoinInfo(EntityPath target, Path alias) {
+		this.targetEntityPath = target;
+		this.alias = alias;
+		this.joinType = 2;
+	}
+
+	public JoinInfo(CollectionExpression target) {
+		this.targetCollection = target;
+		this.joinType = 3;
+	}
+
+	public JoinInfo(CollectionExpression target, Path alias) {
+		this.targetCollection = target;
+		this.alias = alias;
+		this.joinType = 4;
+	}
+
+	public JoinInfo(MapExpression target) {
+		this.targetMap = target;
+		this.joinType = 5;
+	}
+
+	public JoinInfo(MapExpression target, Path alias) {
+		this.targetMap = target;
+		this.alias = alias;
+		this.joinType = 6;
+	}
+
+}

--- a/src/main/java/com/meoguri/linkocean/util/JoinInfoListBuilder.java
+++ b/src/main/java/com/meoguri/linkocean/util/JoinInfoListBuilder.java
@@ -1,0 +1,59 @@
+package com.meoguri.linkocean.util;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.querydsl.core.types.CollectionExpression;
+import com.querydsl.core.types.EntityPath;
+import com.querydsl.core.types.MapExpression;
+import com.querydsl.core.types.Path;
+
+public class JoinInfoListBuilder {
+
+	private List<JoinInfo> joinInfoList = new ArrayList<>();
+
+	public static JoinInfoListBuilder builder() {
+
+		return new JoinInfoListBuilder();
+	}
+
+	public JoinInfoListBuilder join(EntityPath target) {
+
+		this.joinInfoList.add(new JoinInfo(target));
+		return this;
+	}
+
+	public JoinInfoListBuilder join(EntityPath target, Path alias) {
+		this.joinInfoList.add(new JoinInfo(target, alias));
+		return this;
+	}
+
+	public JoinInfoListBuilder join(CollectionExpression target) {
+		this.joinInfoList.add(new JoinInfo(target));
+		return this;
+	}
+
+	public JoinInfoListBuilder join(CollectionExpression target, Path alias) {
+		this.joinInfoList.add(new JoinInfo(target, alias));
+		return this;
+	}
+
+	public JoinInfoListBuilder join(MapExpression target) {
+		this.joinInfoList.add(new JoinInfo(target));
+		return this;
+	}
+
+	public JoinInfoListBuilder join(MapExpression target, Path alias) {
+		this.joinInfoList.add(new JoinInfo(target, alias));
+		return this;
+	}
+
+	public JoinInfoListBuilder fetchJoin() {
+		this.joinInfoList.get(this.joinInfoList.size() - 1).isFetchJoin = true;
+		return this;
+	}
+
+	public List<JoinInfo> build() {
+		return joinInfoList;
+	}
+}

--- a/src/main/java/com/meoguri/linkocean/util/JoinInfoListBuilder.java
+++ b/src/main/java/com/meoguri/linkocean/util/JoinInfoListBuilder.java
@@ -24,7 +24,7 @@ public class JoinInfoListBuilder {
 	/**
 	 * join 메서드 이름을 static, non-static 을 모두 가져가기 위해 내부 클래스를 두었습니다
 	 */
-	public static class JoinInfoListBuilderInitializer {
+	public static class Initializer {
 
 		public static JoinInfoListBuilder join(EntityPath target) {
 			return builder().join(target);

--- a/src/main/java/com/meoguri/linkocean/util/JoinInfoListBuilder.java
+++ b/src/main/java/com/meoguri/linkocean/util/JoinInfoListBuilder.java
@@ -8,17 +8,50 @@ import com.querydsl.core.types.EntityPath;
 import com.querydsl.core.types.MapExpression;
 import com.querydsl.core.types.Path;
 
+/**
+ * 동적 Join 을 제공하기 위한 클래스
+ * JoinInfo 리스트를 Builder 패턴으로 제공한다
+ */
 public class JoinInfoListBuilder {
 
 	private List<JoinInfo> joinInfoList = new ArrayList<>();
 
-	public static JoinInfoListBuilder builder() {
+	private static JoinInfoListBuilder builder() {
 
 		return new JoinInfoListBuilder();
 	}
 
-	public JoinInfoListBuilder join(EntityPath target) {
+	/**
+	 * join 메서드 이름을 static, non-static 을 모두 가져가기 위해 내부 클래스를 두었습니다
+	 */
+	public static class JoinInfoListBuilderInitializer {
 
+		public static JoinInfoListBuilder join(EntityPath target) {
+			return builder().join(target);
+		}
+
+		public static JoinInfoListBuilder join(EntityPath target, Path alias) {
+			return builder().join(target, alias);
+		}
+
+		public static JoinInfoListBuilder join(CollectionExpression target) {
+			return builder().join(target);
+		}
+
+		public static JoinInfoListBuilder join(CollectionExpression target, Path alias) {
+			return builder().join(target, alias);
+		}
+
+		public static JoinInfoListBuilder join(MapExpression target) {
+			return builder().join(target);
+		}
+
+		public static JoinInfoListBuilder join(MapExpression target, Path alias) {
+			return builder().join(target, alias);
+		}
+	}
+
+	public JoinInfoListBuilder join(EntityPath target) {
 		this.joinInfoList.add(new JoinInfo(target));
 		return this;
 	}
@@ -53,7 +86,7 @@ public class JoinInfoListBuilder {
 		return this;
 	}
 
-	public List<JoinInfo> build() {
+	List<JoinInfo> build() {
 		return joinInfoList;
 	}
 }

--- a/src/main/java/com/meoguri/linkocean/util/QueryDslUtil.java
+++ b/src/main/java/com/meoguri/linkocean/util/QueryDslUtil.java
@@ -7,13 +7,10 @@ import java.util.List;
 import java.util.function.Supplier;
 
 import com.querydsl.core.BooleanBuilder;
-import com.querydsl.core.types.EntityPath;
-import com.querydsl.core.types.Path;
 import com.querydsl.core.types.Predicate;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.JPQLQuery;
 
-import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = PRIVATE)
@@ -34,18 +31,33 @@ public final class QueryDslUtil {
 	 * 동적 join 을 지원하기 위한 유틸리티 메서드
 	 */
 	public static <T, P> JPQLQuery<T> joinIf(JPQLQuery<T> base,
-		final JoinEntityPathStore<P> join, final List<Predicate> on, final Boolean when) {
+		final List<JoinInfo> joinInfo, final List<Predicate> on, final Boolean when) {
 
 		if (when) {
-			base = base.join(join.entityPath, join.path)
-				.on(on.toArray(Predicate[]::new));
+			for (JoinInfo pJoinInfo : joinInfo) {
+
+				if (pJoinInfo.joinType == 1) {
+					base = base.join(pJoinInfo.targetEntityPath);
+				} else if (pJoinInfo.joinType == 2) {
+					base = base.join(pJoinInfo.targetEntityPath, pJoinInfo.alias);
+				} else if (pJoinInfo.joinType == 3) {
+					base = base.join(pJoinInfo.targetCollection);
+				} else if (pJoinInfo.joinType == 4) {
+					base = base.join(pJoinInfo.targetCollection, pJoinInfo.alias);
+				} else if (pJoinInfo.joinType == 5) {
+					base = base.join(pJoinInfo.targetMap);
+				} else if (pJoinInfo.joinType == 6) {
+					base = base.join(pJoinInfo.targetMap, pJoinInfo.alias);
+				}
+
+				if (pJoinInfo.isFetchJoin) {
+					base = base.fetchJoin();
+				}
+			}
+
+			base = base.on(on.toArray(Predicate[]::new));
 		}
 		return base;
-	}
-
-	public static <P> JoinEntityPathStore<P> join(final EntityPath<P> target, final Path<P> alias) {
-
-		return new JoinEntityPathStore<>(target, alias);
 	}
 
 	public static boolean when(final boolean cond) {
@@ -57,10 +69,4 @@ public final class QueryDslUtil {
 		return Arrays.asList(condition);
 	}
 
-	@AllArgsConstructor
-	private static class JoinEntityPathStore<P> {
-
-		final EntityPath<P> entityPath;
-		final Path<P> path;
-	}
 }

--- a/src/main/java/com/meoguri/linkocean/util/QueryDslUtil.java
+++ b/src/main/java/com/meoguri/linkocean/util/QueryDslUtil.java
@@ -30,27 +30,28 @@ public final class QueryDslUtil {
 	/**
 	 * 동적 join 을 지원하기 위한 유틸리티 메서드
 	 */
-	public static <T, P> JPQLQuery<T> joinIf(JPQLQuery<T> base,
-		final List<JoinInfo> joinInfo, final List<Predicate> on, final Boolean when) {
+	public static <T> JPQLQuery<T> joinIf(JPQLQuery<T> base,
+		final JoinInfoListBuilder joinInfoListBuilder, final List<Predicate> on, final Boolean when) {
+		final List<JoinInfo> joinInfoList = joinInfoListBuilder.build();
 
 		if (when) {
-			for (JoinInfo pJoinInfo : joinInfo) {
+			for (JoinInfo joinInfo : joinInfoList) {
 
-				if (pJoinInfo.joinType == 1) {
-					base = base.join(pJoinInfo.targetEntityPath);
-				} else if (pJoinInfo.joinType == 2) {
-					base = base.join(pJoinInfo.targetEntityPath, pJoinInfo.alias);
-				} else if (pJoinInfo.joinType == 3) {
-					base = base.join(pJoinInfo.targetCollection);
-				} else if (pJoinInfo.joinType == 4) {
-					base = base.join(pJoinInfo.targetCollection, pJoinInfo.alias);
-				} else if (pJoinInfo.joinType == 5) {
-					base = base.join(pJoinInfo.targetMap);
-				} else if (pJoinInfo.joinType == 6) {
-					base = base.join(pJoinInfo.targetMap, pJoinInfo.alias);
+				if (joinInfo.joinType == 1) {
+					base = base.join(joinInfo.targetEntityPath);
+				} else if (joinInfo.joinType == 2) {
+					base = base.join(joinInfo.targetEntityPath, joinInfo.alias);
+				} else if (joinInfo.joinType == 3) {
+					base = base.join(joinInfo.targetCollection);
+				} else if (joinInfo.joinType == 4) {
+					base = base.join(joinInfo.targetCollection, joinInfo.alias);
+				} else if (joinInfo.joinType == 5) {
+					base = base.join(joinInfo.targetMap);
+				} else if (joinInfo.joinType == 6) {
+					base = base.join(joinInfo.targetMap, joinInfo.alias);
 				}
 
-				if (pJoinInfo.isFetchJoin) {
+				if (joinInfo.isFetchJoin) {
 					base = base.fetchJoin();
 				}
 			}

--- a/src/main/java/com/meoguri/linkocean/util/QueryDslUtil.java
+++ b/src/main/java/com/meoguri/linkocean/util/QueryDslUtil.java
@@ -30,11 +30,15 @@ public final class QueryDslUtil {
 	/**
 	 * 동적 join 을 지원하기 위한 유틸리티 메서드
 	 */
-	public static <T> JPQLQuery<T> joinIf(JPQLQuery<T> base,
-		final JoinInfoListBuilder joinInfoListBuilder, final List<Predicate> on, final Boolean when) {
-		final List<JoinInfo> joinInfoList = joinInfoListBuilder.build();
+	public static <T> JPQLQuery<T> joinIf(
+		JPQLQuery<T> base,
+		final Supplier<JoinInfoListBuilder> joinInfoListBuilder,
+		final List<Predicate> on,
+		final boolean when
+	) {
 
 		if (when) {
+			final List<JoinInfo> joinInfoList = joinInfoListBuilder.get().build();
 			for (JoinInfo joinInfo : joinInfoList) {
 
 				if (joinInfo.joinType == 1) {


### PR DESCRIPTION
## 🛠️ 작업 내용
- joinIf 강화, 북마크 조회 통합 초벌
- 북마크 구현시 아무래도 동적 join 을 다양하게 구사 할것 같아서 기존의 joinIf 로직을 강화시켰습니다.
- 기존에 한번쓰고 치울 생각으로 처리했던 파라미터 타입에 대해서만, chaining 도 없이 단순 하게 구현했었는데
   querydsl 에서 join. 해서 나오는 모든 타입을 핸들링 할 수 있도록 했고 빌더패턴으로 메서드 체이닝을 가능하게 하여 join 여러개 체이닝, fetchJoin 적용등을 가능하게 하였습니다. 
---

- 기존의 프로필 조회에서는 잘 동작하는것을 확인 하였습니다.
- 아직 더 다양한 상황에서의 테스트는 안해봤는데 궁극의 북마크 조회 로직 개발이 기대되네요