### PR TITLE
[LO-77] 중복 URL 확인 API 변경

### DIFF
--- a/src/main/java/com/meoguri/linkocean/controller/bookmark/BookmarkController.java
+++ b/src/main/java/com/meoguri/linkocean/controller/bookmark/BookmarkController.java
@@ -184,14 +184,14 @@ public class BookmarkController {
 		final @AuthenticationPrincipal SecurityUser user,
 		final @RequestParam("url") String url
 	) {
-		final Optional<Bookmark> oBookmark = bookmarkService.getBookmarkToCheck(user.getId(), url);
+		final Optional<Long> oBookmarkId = bookmarkService.getBookmarkToCheck(user.getId(), url);
 
 		HttpHeaders headers = new HttpHeaders();
 
-		oBookmark.ifPresent(bookmark -> {
-			headers.setLocation(URI.create("api/v1/bookmarks/" + bookmark.getId()));
+		oBookmarkId.ifPresent(bookmarkId -> {
+			headers.setLocation(URI.create("api/v1/bookmarks/" + bookmarkId));
 		});
 
-		return ResponseEntity.ok().headers(headers).body(Map.of("isDuplicateUrl", oBookmark.isPresent()));
+		return ResponseEntity.ok().headers(headers).body(Map.of("isDuplicateUrl", oBookmarkId.isPresent()));
 	}
 }

--- a/src/main/java/com/meoguri/linkocean/controller/bookmark/BookmarkController.java
+++ b/src/main/java/com/meoguri/linkocean/controller/bookmark/BookmarkController.java
@@ -8,6 +8,7 @@ import java.net.URISyntaxException;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpHeaders;
@@ -32,6 +33,7 @@ import com.meoguri.linkocean.controller.bookmark.dto.RegisterBookmarkRequest;
 import com.meoguri.linkocean.controller.bookmark.dto.UpdateBookmarkRequest;
 import com.meoguri.linkocean.controller.common.PageResponse;
 import com.meoguri.linkocean.controller.common.SimpleIdResponse;
+import com.meoguri.linkocean.domain.bookmark.entity.Bookmark;
 import com.meoguri.linkocean.domain.bookmark.service.BookmarkService;
 import com.meoguri.linkocean.domain.bookmark.service.dto.GetBookmarksResult;
 import com.meoguri.linkocean.domain.bookmark.service.dto.GetDetailedBookmarkResult;
@@ -182,14 +184,14 @@ public class BookmarkController {
 		final @AuthenticationPrincipal SecurityUser user,
 		final @RequestParam("url") String url
 	) {
-		final boolean isDuplicated = bookmarkService.checkDuplicatedUrl(user.getId(), url);
+		final Optional<Bookmark> oBookmark = bookmarkService.getBookmarkToCheck(user.getId(), url);
+
 		HttpHeaders headers = new HttpHeaders();
 
-		//TODO: haeder에 bookmarkid 반환
-		if (isDuplicated) {
-			headers.setLocation(URI.create(url));
-		}
+		oBookmark.ifPresent(bookmark -> {
+			headers.setLocation(URI.create("api/v1/bookmarks/" + bookmark.getId()));
+		});
 
-		return ResponseEntity.ok().headers(headers).body(Map.of("isDuplicateUrl", isDuplicated));
+		return ResponseEntity.ok().headers(headers).body(Map.of("isDuplicateUrl", oBookmark.isPresent()));
 	}
 }

--- a/src/main/java/com/meoguri/linkocean/domain/bookmark/persistence/BookmarkRepository.java
+++ b/src/main/java/com/meoguri/linkocean/domain/bookmark/persistence/BookmarkRepository.java
@@ -16,7 +16,7 @@ public interface BookmarkRepository extends JpaRepository<Bookmark, Long>, Custo
 
 	Optional<Bookmark> findByProfileAndId(Profile profile, long id);
 
-	boolean existsByProfileAndUrl(final Profile profile, final String url);
+	Optional<Bookmark> findByProfileAndUrl(Profile profile, String url);
 
 	@Query("select distinct b "
 		+ "from Bookmark b "

--- a/src/main/java/com/meoguri/linkocean/domain/bookmark/service/BookmarkService.java
+++ b/src/main/java/com/meoguri/linkocean/domain/bookmark/service/BookmarkService.java
@@ -1,10 +1,12 @@
 package com.meoguri.linkocean.domain.bookmark.service;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import com.meoguri.linkocean.domain.bookmark.entity.Bookmark;
 import com.meoguri.linkocean.domain.bookmark.service.dto.FeedBookmarksSearchCond;
 import com.meoguri.linkocean.domain.bookmark.service.dto.GetBookmarksResult;
 import com.meoguri.linkocean.domain.bookmark.service.dto.GetDetailedBookmarkResult;
@@ -39,5 +41,5 @@ public interface BookmarkService {
 	List<GetFeedBookmarksResult> getFeedBookmarks(FeedBookmarksSearchCond searchCond);
 
 	/* 중복Url 확인 */
-	boolean checkDuplicatedUrl(long userId, String url);
+	Optional<Bookmark> getBookmarkToCheck(long userId, String url);
 }

--- a/src/main/java/com/meoguri/linkocean/domain/bookmark/service/BookmarkService.java
+++ b/src/main/java/com/meoguri/linkocean/domain/bookmark/service/BookmarkService.java
@@ -41,5 +41,5 @@ public interface BookmarkService {
 	List<GetFeedBookmarksResult> getFeedBookmarks(FeedBookmarksSearchCond searchCond);
 
 	/* 중복Url 확인 */
-	Optional<Bookmark> getBookmarkToCheck(long userId, String url);
+	Optional<Long> getBookmarkToCheck(long userId, String url);
 }

--- a/src/main/java/com/meoguri/linkocean/domain/bookmark/service/BookmarkServiceImpl.java
+++ b/src/main/java/com/meoguri/linkocean/domain/bookmark/service/BookmarkServiceImpl.java
@@ -275,8 +275,13 @@ public class BookmarkServiceImpl implements BookmarkService {
 	}
 
 	@Override
-	public Optional<Bookmark> getBookmarkToCheck(final long userId, String url) {
+	public Optional<Long> getBookmarkToCheck(final long userId, String url) {
 		final Profile profile = findProfileByUserIdQuery.findByUserId(userId);
-		return bookmarkRepository.findByProfileAndUrl(profile, url);
+		final Optional<Bookmark> oBookmark = bookmarkRepository.findByProfileAndUrl(profile, url);
+
+		if (oBookmark.isPresent()) {
+			return Optional.of(profile.getId());
+		}
+		return Optional.empty();
 	}
 }

--- a/src/main/java/com/meoguri/linkocean/domain/bookmark/service/BookmarkServiceImpl.java
+++ b/src/main/java/com/meoguri/linkocean/domain/bookmark/service/BookmarkServiceImpl.java
@@ -275,8 +275,8 @@ public class BookmarkServiceImpl implements BookmarkService {
 	}
 
 	@Override
-	public boolean checkDuplicatedUrl(final long userId, String url) {
+	public Optional<Bookmark> getBookmarkToCheck(final long userId, String url) {
 		final Profile profile = findProfileByUserIdQuery.findByUserId(userId);
-		return bookmarkRepository.existsByProfileAndUrl(profile, url);
+		return bookmarkRepository.findByProfileAndUrl(profile, url);
 	}
 }

--- a/src/test/java/com/meoguri/linkocean/controller/bookmark/BookmarkControllerTest.java
+++ b/src/test/java/com/meoguri/linkocean/controller/bookmark/BookmarkControllerTest.java
@@ -207,6 +207,8 @@ class BookmarkControllerTest extends BaseControllerTest {
 
 	@Test
 	void Url중복확인_성공_새로운_url() throws Exception {
+		//given
+		final String locationHeader = "Location";
 
 		//when
 		mockMvc.perform(get(basePath + "?url=https://www.google.com")
@@ -215,8 +217,33 @@ class BookmarkControllerTest extends BaseControllerTest {
 
 			//then
 			.andExpect(status().isOk())
+			.andExpect(header().doesNotExist(locationHeader))
 			.andExpectAll(
 				jsonPath("$.isDuplicateUrl").value(false)
+			).andDo(print());
+	}
+
+	@Test
+	void Url중복확인_성공_이미있는_url() throws Exception {
+
+		//given
+		final long duplicatedBookmarkId = 북마크_등록(링크_메타데이터_얻기("https://www.google.com"), "title1", "IT", List.of("공부"),
+			"all");
+		final String locationHeader = "Location";
+		final String locationHeaderValue = "api/v1/bookmarks/" + duplicatedBookmarkId;
+
+		//when
+		mockMvc.perform(get(basePath + "?url=https://www.google.com")
+				.header(AUTHORIZATION, token)
+				.accept(APPLICATION_JSON))
+
+			//then
+			.andExpect(status().isOk())
+
+			/**/
+			.andExpect(header().string(locationHeader, locationHeaderValue))
+			.andExpectAll(
+				jsonPath("$.isDuplicateUrl").value(true)
 			).andDo(print());
 	}
 

--- a/src/test/java/com/meoguri/linkocean/domain/bookmark/persistence/BookmarkRepositoryTest.java
+++ b/src/test/java/com/meoguri/linkocean/domain/bookmark/persistence/BookmarkRepositoryTest.java
@@ -194,19 +194,21 @@ class BookmarkRepositoryTest {
 		bookmarkRepository.save(createBookmark(profile, link, "제목", "인문", "https://www.google.com"));
 
 		//when
-		final boolean isExist = bookmarkRepository.existsByProfileAndUrl(profile, "https://www.google.com");
+		final Optional<Bookmark> sameUrlBookmark = bookmarkRepository.findByProfileAndUrl(profile,
+			"https://www.google.com");
 
 		//then
-		assertThat(isExist).isTrue();
+		assertThat(sameUrlBookmark).isPresent();
 	}
 
 	@Test
 	void Url_검색시_해당_Url_없음() {
 
 		//when
-		final boolean isExist = bookmarkRepository.existsByProfileAndUrl(profile, "https://www.linkocean.com");
+		final Optional<Bookmark> sameUrlBookmark = bookmarkRepository.findByProfileAndUrl(profile,
+			"https://www.google.com");
 
 		//then
-		assertThat(isExist).isFalse();
+		assertThat(sameUrlBookmark).isEmpty();
 	}
 }

--- a/src/test/java/com/meoguri/linkocean/domain/bookmark/service/BookmarkServiceImplTest.java
+++ b/src/test/java/com/meoguri/linkocean/domain/bookmark/service/BookmarkServiceImplTest.java
@@ -526,19 +526,19 @@ class BookmarkServiceImplTest {
 		final Bookmark bookmark = bookmarkRepository.save(createBookmark(profile, linkMetadata));
 
 		//when
-		final Optional<Bookmark> duplicatedUrlBookmark = bookmarkService.getBookmarkToCheck(userId, bookmark.getUrl());
+		final Optional<Long> duplicatedUrlBookmarkId = bookmarkService.getBookmarkToCheck(userId, bookmark.getUrl());
 
 		//then
-		assertThat(duplicatedUrlBookmark).isPresent();
+		assertThat(duplicatedUrlBookmarkId).isPresent();
 	}
 
 	@Test
 	void 중복_Url_없을_때() {
 
 		//when
-		final Optional<Bookmark> duplicatedUrlBookmark = bookmarkService.getBookmarkToCheck(userId, "https://www.does.not.exist");
+		final Optional<Long> duplicatedUrlBookmarkId = bookmarkService.getBookmarkToCheck(userId, "https://www.does.not.exist");
 
 		//then
-		assertThat(duplicatedUrlBookmark).isEmpty();
+		assertThat(duplicatedUrlBookmarkId).isEmpty();
 	}
 }

--- a/src/test/java/com/meoguri/linkocean/domain/bookmark/service/BookmarkServiceImplTest.java
+++ b/src/test/java/com/meoguri/linkocean/domain/bookmark/service/BookmarkServiceImplTest.java
@@ -526,19 +526,19 @@ class BookmarkServiceImplTest {
 		final Bookmark bookmark = bookmarkRepository.save(createBookmark(profile, linkMetadata));
 
 		//when
-		final boolean isDuplicateUrl = bookmarkService.checkDuplicatedUrl(userId, bookmark.getUrl());
+		final Optional<Bookmark> duplicatedUrlBookmark = bookmarkService.getBookmarkToCheck(userId, bookmark.getUrl());
 
 		//then
-		assertThat(isDuplicateUrl).isTrue();
+		assertThat(duplicatedUrlBookmark).isPresent();
 	}
 
 	@Test
 	void 중복_Url_없을_때() {
 
 		//when
-		final boolean isDuplicateUrl = bookmarkService.checkDuplicatedUrl(userId, "https://www.does.not.exist");
+		final Optional<Bookmark> duplicatedUrlBookmark = bookmarkService.getBookmarkToCheck(userId, "https://www.does.not.exist");
 
 		//then
-		assertThat(isDuplicateUrl).isFalse();
+		assertThat(duplicatedUrlBookmark).isEmpty();
 	}
 }


### PR DESCRIPTION
## 🛠️ 작업 내용
- 중복 url 관련 repository method에서 Optional<Bookmark> 반환으로 변경하였습니다. 이에 따라 test 검증도 optional 검증으로 변경하였습니다.
- 중복 url 관련 service에서 repository 변경에 따라 Optional<Bookmark> 반환으로 변경하였습니다.
- 중복 url controller 리팩토링이 있었으며 관련 반대 test case 추가 및 header 검증 추가하였습니다.

## 🗨️ 기타
- 현재 중복 URL API는 userId 를 사용하기 때문에 차후에 profileId 사용으로 변경하겠습니다.
