### PR TITLE
[LO-133] 프로필 목록 조회 영속성 계층 리팩토링

### DIFF
--- a/src/main/java/com/meoguri/linkocean/domain/profile/persistence/CustomProfileRepository.java
+++ b/src/main/java/com/meoguri/linkocean/domain/profile/persistence/CustomProfileRepository.java
@@ -2,8 +2,12 @@ package com.meoguri.linkocean.domain.profile.persistence;
 
 import java.util.List;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
 import com.meoguri.linkocean.domain.profile.entity.Profile;
 import com.meoguri.linkocean.domain.profile.persistence.dto.ProfileFindCond;
+import com.meoguri.linkocean.domain.profile.persistence.dto.UltimateProfileFindCond;
 
 public interface CustomProfileRepository {
 
@@ -12,4 +16,6 @@ public interface CustomProfileRepository {
 	List<Profile> findFolloweeProfilesBy(ProfileFindCond findCond);
 
 	List<Profile> findByUsernameLike(ProfileFindCond findCond);
+
+	Page<Profile> ultimateFindProfiles(UltimateProfileFindCond findCond, Pageable pageable);
 }

--- a/src/main/java/com/meoguri/linkocean/domain/profile/persistence/CustomProfileRepositoryImpl.java
+++ b/src/main/java/com/meoguri/linkocean/domain/profile/persistence/CustomProfileRepositoryImpl.java
@@ -8,18 +8,46 @@ import java.util.List;
 
 import javax.persistence.EntityManager;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
 import com.meoguri.linkocean.domain.profile.entity.Profile;
 import com.meoguri.linkocean.domain.profile.persistence.dto.ProfileFindCond;
+import com.meoguri.linkocean.domain.profile.persistence.dto.UltimateProfileFindCond;
 import com.meoguri.linkocean.util.Querydsl4RepositorySupport;
 import com.querydsl.core.BooleanBuilder;
+import com.querydsl.jpa.impl.JPAQuery;
 
 @Repository
 public class CustomProfileRepositoryImpl extends Querydsl4RepositorySupport implements CustomProfileRepository {
 
 	public CustomProfileRepositoryImpl(final EntityManager em) {
 		super(Profile.class);
+	}
+
+	@Override
+	public Page<Profile> ultimateFindProfiles(final UltimateProfileFindCond findCond, final Pageable pageable) {
+
+		final Long currentProfileId = findCond.getProfileId();
+		final boolean isFollower = findCond.isFollower();
+		final boolean isFollowee = findCond.isFollowee();
+		final String username = findCond.getUsername();
+
+		final JPAQuery<Profile> base = selectFrom(profile);
+
+		if (isFollower) {
+			return applyPaginationWithoutTotalPage(
+				pageable, base.where(followerOfUsername(currentProfileId, username)));
+		}
+
+		if (isFollowee) {
+			return applyPaginationWithoutTotalPage(
+				pageable, base.where(followeeOfUsername(currentProfileId, username)));
+		}
+
+		return applyPaginationWithoutTotalPage(
+			pageable, base.where(usernameContains(username)));
 	}
 
 	@Override
@@ -66,7 +94,7 @@ public class CustomProfileRepositoryImpl extends Querydsl4RepositorySupport impl
 					.on(follow.follower.id.eq(profile.id))
 			).where(
 				follow.followee.id.eq(profileId),
-				usernameLike(username)
+				usernameContains(username)
 			))
 		);
 	}
@@ -82,7 +110,7 @@ public class CustomProfileRepositoryImpl extends Querydsl4RepositorySupport impl
 					.on(follow.followee.id.eq(profile.id))
 			).where(
 				follow.follower.id.eq(profileId),
-				usernameLike(username)
+				usernameContains(username)
 			))
 		);
 	}
@@ -91,5 +119,9 @@ public class CustomProfileRepositoryImpl extends Querydsl4RepositorySupport impl
 	private BooleanBuilder usernameLike(final String username) {
 
 		return nullSafeBuilder(() -> profile.username.like(String.join(username, "%", "%")));
+	}
+
+	private BooleanBuilder usernameContains(final String username) {
+		return nullSafeBuilder(() -> profile.username.containsIgnoreCase(username));
 	}
 }

--- a/src/main/java/com/meoguri/linkocean/domain/profile/persistence/dto/UltimateProfileFindCond.java
+++ b/src/main/java/com/meoguri/linkocean/domain/profile/persistence/dto/UltimateProfileFindCond.java
@@ -1,0 +1,37 @@
+package com.meoguri.linkocean.domain.profile.persistence.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 프로필 목록 조회 조건
+ * - 사용자 팔로우 목록 조회
+ * - 사용자 팔로이 목록 조회
+ * - 다른 사용자 이름 검색
+ */
+@Getter
+@Builder
+@RequiredArgsConstructor
+public class UltimateProfileFindCond {
+
+	/**
+	 * 팔로우, 팔로이 목록 조회에서 현재 사용자의 프로필 아이디
+	 */
+	private final Long profileId;
+
+	/**
+	 * 팔로워 목록 조회
+	 */
+	private final boolean follower;
+
+	/**
+	 * 팔로이 목록 조회
+	 */
+	private final boolean followee;
+
+	/**
+	 * 검색하고 싶은 사용자의 username
+	 */
+	private final String username;
+}

--- a/src/main/java/com/meoguri/linkocean/util/Querydsl4RepositorySupport.java
+++ b/src/main/java/com/meoguri/linkocean/util/Querydsl4RepositorySupport.java
@@ -137,6 +137,17 @@ public abstract class Querydsl4RepositorySupport {
 		return PageableExecutionUtils.getPage(content, pageable, () -> jpaCountQuery.stream().count());
 	}
 
+	/**
+	 * 무한 스크롤 전용 페이지네이션 : total count 필요 없음
+	 */
+	protected <T> Page<T> applyPaginationWithoutTotalPage(
+		Pageable pageable,
+		JPAQuery<T> jpaContentQuery
+	) {
+		List<T> content = getQuerydsl().applyPagination(pageable, jpaContentQuery).fetch();
+		return PageableExecutionUtils.getPage(content, pageable, () -> 0L);
+	}
+
 	private Pageable convertBookmarkSort(Pageable pageable) {
 		return QPageRequest.of(
 			pageable.getPageNumber(),

--- a/src/test/java/com/meoguri/linkocean/domain/profile/persistence/CustomProfileRepositoryImplTest.java
+++ b/src/test/java/com/meoguri/linkocean/domain/profile/persistence/CustomProfileRepositoryImplTest.java
@@ -4,17 +4,30 @@ import static org.assertj.core.api.Assertions.*;
 
 import java.util.List;
 
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 
+import com.meoguri.linkocean.common.CustomP6spySqlFormat;
+import com.meoguri.linkocean.common.Ultimate;
 import com.meoguri.linkocean.domain.profile.entity.Follow;
 import com.meoguri.linkocean.domain.profile.entity.Profile;
 import com.meoguri.linkocean.domain.profile.persistence.dto.ProfileFindCond;
+import com.meoguri.linkocean.domain.profile.persistence.dto.UltimateProfileFindCond;
 import com.meoguri.linkocean.domain.user.entity.User;
 import com.meoguri.linkocean.domain.user.repository.UserRepository;
 
+@Import(CustomP6spySqlFormat.class)
 @DataJpaTest
 class CustomProfileRepositoryImplTest {
 
@@ -26,6 +39,9 @@ class CustomProfileRepositoryImplTest {
 
 	@Autowired
 	private FollowRepository followRepository;
+
+	@PersistenceContext
+	private EntityManager em;
 
 	private Profile profile1;
 	private Profile profile2;
@@ -43,6 +59,116 @@ class CustomProfileRepositoryImplTest {
 		profile3 = profileRepository.save(new Profile(user3, "user3"));
 	}
 
+	@Ultimate
+	@Nested
+	class 궁극의_프로필_목록_조회_테스트 {
+
+		@Test
+		void 팔로워_목록_조회_성공_이름_지정_X() {
+			//given
+			followRepository.save(new Follow(profile1, profile2));
+			followRepository.save(new Follow(profile1, profile3));
+			followRepository.save(new Follow(profile2, profile3));
+
+			//when
+			final Page<Profile> followerOfUser1 = profileRepository.ultimateFindProfiles(
+				condWhenFindFollowers(profile1.getId()), defaultPageable());
+			final Page<Profile> followerOfUser2 = profileRepository.ultimateFindProfiles(
+				condWhenFindFollowers(profile2.getId()), defaultPageable());
+			final Page<Profile> followerOfUser3 = profileRepository.ultimateFindProfiles(
+				condWhenFindFollowers(profile3.getId()), defaultPageable());
+
+			//then
+			assertThat(followerOfUser1).isEmpty();
+			assertThat(followerOfUser2).containsExactly(profile1);
+			assertThat(followerOfUser3).containsExactly(profile1, profile2);
+		}
+
+		@Test
+		void 팔로워_목록_조회_성공_이름_지정() {
+			//given
+			followRepository.save(new Follow(profile1, profile3));
+			followRepository.save(new Follow(profile2, profile3));
+
+			//when
+			final Page<Profile> followerOfUser1 = profileRepository.ultimateFindProfiles(
+				condWhenFindFollowers(profile3.getId(), "user1"), defaultPageable());
+
+			//then
+			assertThat(followerOfUser1).containsExactly(profile1);
+		}
+
+		@Test
+		void 팔로이_목록_조회_성공_이름_지정_X() {
+			//given
+			followRepository.save(new Follow(profile1, profile2));
+			followRepository.save(new Follow(profile1, profile3));
+			followRepository.save(new Follow(profile2, profile3));
+
+			//when
+			final Page<Profile> followerOfUser1 = profileRepository.ultimateFindProfiles(
+				condWhenFindFollowees(profile1.getId()), defaultPageable());
+			final Page<Profile> followerOfUser2 = profileRepository.ultimateFindProfiles(
+				condWhenFindFollowees(profile2.getId()), defaultPageable());
+			final Page<Profile> followerOfUser3 = profileRepository.ultimateFindProfiles(
+				condWhenFindFollowees(profile3.getId()), defaultPageable());
+
+			//then
+			assertThat(followerOfUser1).containsExactly(profile2, profile3);
+			assertThat(followerOfUser2).containsExactly(profile3);
+			assertThat(followerOfUser3).isEmpty();
+		}
+
+		@Test
+		void 팔로이_목록_조회_성공_이름_지정() {
+			//given
+			followRepository.save(new Follow(profile1, profile2));
+			followRepository.save(new Follow(profile1, profile3));
+
+			//when
+			final Page<Profile> followerOfUser1 = profileRepository.ultimateFindProfiles(
+				condWhenFindFollowees(profile1.getId(), "user3"), defaultPageable());
+
+			//then
+			assertThat(followerOfUser1).containsExactly(profile3);
+		}
+
+		@Test
+		void 프로필_목록_조회_성공_이름_지정() {
+			//when
+			final Page<Profile> profiles = profileRepository.ultimateFindProfiles(condWhenFindUsingUsername("user"),
+				defaultPageable());
+
+			//then
+			assertThat(profiles).containsExactly(profile1, profile2, profile3);
+		}
+	}
+
+	private UltimateProfileFindCond condWhenFindUsingUsername(final String username) {
+		return UltimateProfileFindCond.builder().username(username).build();
+	}
+
+	private UltimateProfileFindCond condWhenFindFollowees(final long profileId) {
+		return condWhenFindFollowees(profileId, null);
+	}
+
+	private UltimateProfileFindCond condWhenFindFollowees(final long profileId, final String username) {
+		return UltimateProfileFindCond.builder().profileId(profileId).followee(true).username(username).build();
+	}
+
+	private UltimateProfileFindCond condWhenFindFollowers(final long profileId) {
+		return condWhenFindFollowers(profileId, null);
+	}
+
+	private UltimateProfileFindCond condWhenFindFollowers(final long profileId, final String username) {
+		return UltimateProfileFindCond.builder().profileId(profileId).follower(true).username(username).build();
+	}
+
+	private Pageable defaultPageable() {
+		return PageRequest.of(0, 8);
+	}
+
+	@Disabled("곧 삭제 예정")
 	@Test
 	void 팔로워_목록조회_성공_이름_지정_X() {
 		//given
@@ -61,6 +187,7 @@ class CustomProfileRepositoryImplTest {
 		assertThat(followerOfUser3).containsExactly(profile1, profile2);
 	}
 
+	@Disabled("삭제 예정")
 	@Test
 	void 팔로워_목록조회_성공_이름_지정() {
 		//given
@@ -74,6 +201,7 @@ class CustomProfileRepositoryImplTest {
 		assertThat(followerOfUser1).containsExactly(profile1);
 	}
 
+	@Disabled("삭제 예정")
 	@Test
 	void 팔로이_목록조회_성공_이름_지정_X() {
 		//given
@@ -92,6 +220,7 @@ class CustomProfileRepositoryImplTest {
 		assertThat(followerOfUser3).isEmpty();
 	}
 
+	@Disabled("삭제 예정")
 	@Test
 	void 팔로이_목록조회_성공_이름_지정() {
 		//given
@@ -105,6 +234,7 @@ class CustomProfileRepositoryImplTest {
 		assertThat(followerOfUser1).containsExactly(profile3);
 	}
 
+	@Disabled("삭제 예정")
 	@Test
 	void 프로필_목록조회_성공_이름_지정() {
 		//when


### PR DESCRIPTION
## 🛠️ 작업 내용
- 프로필 목록 조회 영속성 계층 리팩토링

## 🗨️ 기타
<!-- PR 포인트 혹은 궁금한 점 등등 적어주시면 됩니다. 없으시면 지워주세요 -->
- 기존에 3개로 나윘었던 프로필 목록 조회 영속성 API들을 하나로 합쳤습니다. (팔로워 목록 조회, 팔로이 목록 조회, 이름으로 프로필 목록 검색)
- @Disable로 표시된 테스트는 리팩토링이 완료되면 제거될 친구들입니다.
- 프로필 목록 조회 조인에서 삽질해서 생각보다 오래걸렸네요. ㅎㅎ

## 😎 리뷰어
@ndy2 , @jk05018 , @NewEgoDoc, @hyuk0309
