### PR TITLE
[LO-156] login, follow, notification, linkMetadata, profile restdocs 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -149,8 +149,8 @@ task copyDev(type: Copy) {
 }
 
 tasks.named('asciidoctor') {
-    inputs.dir snippetsDir
     dependsOn test
+    inputs.dir snippetsDir
 }
 
 build {

--- a/docs/asciidoc/FOLLOW-API.adoc
+++ b/docs/asciidoc/FOLLOW-API.adoc
@@ -1,0 +1,12 @@
+[[FOLLOW-API]]
+== 팔로우 API
+
+'''
+
+=== 팔로우
+
+operation::/follow-docs-controller/팔로우_api/[snippets='http-request,request-parameters,http-response']
+
+=== 언팔로우
+
+operation::/follow-docs-controller/언팔로우_api/[snippets='http-request,request-parameters,http-response']

--- a/docs/asciidoc/LINKMETADATA-API.adoc
+++ b/docs/asciidoc/LINKMETADATA-API.adoc
@@ -1,0 +1,8 @@
+[[LINKMETADATA-API]]
+== 링크 메타데이터 API
+
+'''
+
+=== 링크 메타데이터 조회
+
+operation::/link-metadata-docs-controller/링크메타데이터_제목_조회_-api/[snippets='http-request,request-parameters,http-response,response-body,response-fields']

--- a/docs/asciidoc/LOGIN-API.adoc
+++ b/docs/asciidoc/LOGIN-API.adoc
@@ -1,0 +1,12 @@
+[[LOGIN-API]]
+== 로그인 API
+
+'''
+
+=== 로그인
+
+operation::/login-docs-controller/로그인_api/[snippets='http-request,request-fields,http-response,response-fields']
+
+=== 로그인 성공
+
+operation::/login-docs-controller/로그인_성공_api/[snippets='http-request,http-response,response-fields']

--- a/docs/asciidoc/NOTIFICATION-API.adoc
+++ b/docs/asciidoc/NOTIFICATION-API.adoc
@@ -1,0 +1,8 @@
+[[NOTIFICATION-API]]
+== 알림 API
+
+'''
+
+=== 알림 목록 조회
+
+operation::/notification-docs-controller/공유_알림_생성하고_조회_성공/[snippets='http-request,request-parameters,http-response,response-fields']

--- a/docs/asciidoc/PROFILE_API.adoc
+++ b/docs/asciidoc/PROFILE_API.adoc
@@ -1,0 +1,28 @@
+[[PROFILE-API]]
+== 프로필 API
+
+'''
+
+=== 프로필 등록
+
+operation::/profile-docs-controller/프로필_등록_api/[snippets='http-request,request-fields,http-response,response-fields']
+
+=== 내 프로필 수정
+
+operation::/profile-docs-controller/내_프로필_수정_api/[snippets='http-request,request-parameters,request-parts,http-response']
+
+=== 내 프로필 조회
+
+operation::/profile-docs-controller/내프로필_조회_api/[snippets='http-request,response-body,response-fields']
+
+=== 다른 사람 프로필 조회
+
+operation::/profile-docs-controller/다른_사람_프로필_조회_api/[snippets='http-request,path-parameters,response-body,response-fields']
+
+=== 팔로우/팔로워 전체 조회
+
+operation::/프로필_목록_조회_시리즈_테스트/팔로워_조회_-api_성공/[snippets='http-request,path-parameters,request-parameters,response-body,response-fields']
+
+=== 프로필 목록 조회 - 머구리 찾기
+
+operation::/프로필_목록_조회_시리즈_테스트/프로필_목록_조회_api/[snippets='http-request,request-parameters,response-body,response-fields']

--- a/docs/asciidoc/index.adoc
+++ b/docs/asciidoc/index.adoc
@@ -1,0 +1,14 @@
+= LinkOcean
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 2
+:sectlinks:
+:docinfo: shared-head
+
+include::LOGIN-API.adoc[]
+include::PROFILE_API.adoc[]
+include::FOLLOW-API.adoc[]
+include::NOTIFICATION-API.adoc[]
+include::LINKMETADATA-API.adoc[]

--- a/src/test/java/com/meoguri/linkocean/controller/restdocs/FollowDocsController.java
+++ b/src/test/java/com/meoguri/linkocean/controller/restdocs/FollowDocsController.java
@@ -1,0 +1,83 @@
+package com.meoguri.linkocean.controller.restdocs;
+
+import static org.springframework.http.HttpHeaders.*;
+import static org.springframework.http.MediaType.*;
+import static org.springframework.restdocs.headers.HeaderDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.meoguri.linkocean.controller.profile.FollowController;
+import com.meoguri.linkocean.controller.support.RestDocsTestSupport;
+
+public class FollowDocsController extends RestDocsTestSupport {
+	private final String baseUrl = getBaseUrl(FollowController.class);
+
+	long hahaId;
+
+	@BeforeEach
+	void setUp() throws Exception {
+		//given - 두 사용자 haha 와 papa
+		유저_등록_로그인("haha@gmail.com", "GOOGLE");
+		hahaId = 프로필_등록("haha", List.of("IT"));
+
+		유저_등록_로그인("papa@gmail.com", "GOOGLE");
+		프로필_등록("papa", List.of("자기계발"));
+	}
+
+	@Test
+	void 팔로우_api() throws Exception {
+		//when
+		mockMvc.perform(post(baseUrl + "/follow")
+				.param("followeeId", String.valueOf(hahaId))
+				.header(AUTHORIZATION, token))
+
+			//then
+			.andExpect(status().isOk())
+
+			//docs
+			.andDo(
+				restDocs.document(
+					requestHeaders(
+						headerWithName(AUTHORIZATION).description("인증 토큰")
+					),
+					requestParameters(
+						parameterWithName("followeeId").description("팔로위 ID")
+					)
+				)
+			);
+	}
+
+	@Test
+	void 언팔로우_api() throws Exception {
+		//given
+		팔로우(hahaId);
+
+		//when
+		mockMvc.perform(post(baseUrl + "/unfollow")
+				.param("followeeId", String.valueOf(hahaId))
+				.header(AUTHORIZATION, token)
+				.contentType(APPLICATION_JSON))
+
+			//then
+			.andExpect(status().isOk())
+
+			//docs
+			.andDo(
+				restDocs.document(
+					requestHeaders(
+						headerWithName(AUTHORIZATION).description("인증 토큰")
+					),
+					requestParameters(
+						parameterWithName("followeeId").description("팔로위 ID")
+					)
+				)
+			);
+
+	}
+}

--- a/src/test/java/com/meoguri/linkocean/controller/restdocs/LinkMetadataDocsController.java
+++ b/src/test/java/com/meoguri/linkocean/controller/restdocs/LinkMetadataDocsController.java
@@ -1,0 +1,59 @@
+package com.meoguri.linkocean.controller.restdocs;
+
+import static org.springframework.http.HttpHeaders.*;
+import static org.springframework.restdocs.headers.HeaderDocumentation.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import com.meoguri.linkocean.controller.linkmetadata.LinkMetadataController;
+import com.meoguri.linkocean.controller.support.RestDocsTestSupport;
+
+public class LinkMetadataDocsController extends RestDocsTestSupport {
+
+	private final String basePath = getBaseUrl(LinkMetadataController.class);
+
+	@Test
+	void 링크메타데이터_제목_조회_Api() throws Exception {
+		//given
+		유저_등록_로그인("hani@gmail.com", "GOOGLE");
+		프로필_등록("hani", List.of("정치", "인문", "사회"));
+
+		final String link = "http://www.naver.com";
+		//when
+		mockMvc.perform(post(UriComponentsBuilder.fromUriString(basePath)
+				.pathSegment("obtain")
+				.queryParam("link", link)
+				.build()
+				.toUri())
+				.header(AUTHORIZATION, token)
+				.contentType(MediaType.APPLICATION_JSON))
+
+			//then
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.title").exists())
+
+			//docs
+			.andDo(
+				restDocs.document(
+					requestHeaders(
+						headerWithName(AUTHORIZATION).description("인증 토큰")
+					),
+					requestParameters(
+						parameterWithName("link").description("url 링크")
+					),
+					responseFields(
+						fieldWithPath("title").optional().description("링크 메타데이터 제목")
+					)
+				)
+			);
+
+	}
+}

--- a/src/test/java/com/meoguri/linkocean/controller/restdocs/LoginDocsController.java
+++ b/src/test/java/com/meoguri/linkocean/controller/restdocs/LoginDocsController.java
@@ -1,0 +1,84 @@
+package com.meoguri.linkocean.controller.restdocs;
+
+import static org.springframework.http.HttpHeaders.*;
+import static org.springframework.restdocs.headers.HeaderDocumentation.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+
+import com.meoguri.linkocean.controller.support.RestDocsTestSupport;
+import com.meoguri.linkocean.controller.user.LoginController;
+import com.meoguri.linkocean.controller.user.dto.LoginRequest;
+
+public class LoginDocsController extends RestDocsTestSupport {
+
+	private final String basePath = getBaseUrl(LoginController.class);
+
+	@Test
+	void 로그인_api() throws Exception {
+		//given
+		final String email = "jk05018@naver.com";
+		final String oauthType = "NAVER";
+
+		final LoginRequest loginRequest = new LoginRequest(email, oauthType);
+
+		//when
+		mockMvc.perform(post(basePath)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(createJson(loginRequest)))
+
+			//then
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.token").exists())
+
+			//docs
+			.andDo(
+				restDocs.document(
+					requestFields(
+						fieldWithPath("email").description("이메일"),
+						fieldWithPath("oauthType").description("소셜 타입[GOOGLE, NAVER, KAKAO]")
+					),
+					responseFields(
+						fieldWithPath("token").description("jwt 토큰")
+					)
+				)
+			);
+
+	}
+
+	@Test
+	void 로그인_성공_api() throws Exception {
+		//given
+		유저_등록_로그인("hani@gmail.com", "GOOGLE");
+		프로필_등록("hani", List.of("정치", "인문", "사회"));
+
+		//when
+		mockMvc.perform(get(basePath + "/success")
+				.header(AUTHORIZATION, token)
+				.contentType(MediaType.APPLICATION_JSON))
+
+			//then
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.hasProfile").value(true))
+			.andDo(print())
+
+			//docs
+			.andDo(
+				restDocs.document(
+					requestHeaders(
+						headerWithName(AUTHORIZATION).description("인증 토큰")
+					),
+					responseFields(
+						fieldWithPath("hasProfile").description("이메일")
+					)
+				)
+			);
+
+	}
+}

--- a/src/test/java/com/meoguri/linkocean/controller/restdocs/NotificationDocsController.java
+++ b/src/test/java/com/meoguri/linkocean/controller/restdocs/NotificationDocsController.java
@@ -1,0 +1,114 @@
+package com.meoguri.linkocean.controller.restdocs;
+
+import static java.util.Collections.*;
+import static org.hamcrest.Matchers.*;
+import static org.springframework.http.HttpHeaders.*;
+import static org.springframework.http.MediaType.*;
+import static org.springframework.restdocs.headers.HeaderDocumentation.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.meoguri.linkocean.controller.notification.NotificationController;
+import com.meoguri.linkocean.controller.support.RestDocsTestSupport;
+
+public class NotificationDocsController extends RestDocsTestSupport {
+
+	private final String baseUrl = getBaseUrl(NotificationController.class);
+
+	private long senderProfileId;
+	private long shareBookmarkId;
+	private long targetProfileId;
+	private long unsharableBookmarkId;
+
+	@BeforeEach
+	void setUp() throws Exception {
+		유저_등록_로그인("sender@gmail.com", "GOOGLE");
+		senderProfileId = 프로필_등록("sender", List.of("IT"));
+		shareBookmarkId = 북마크_등록(링크_메타데이터_얻기("http://www.naver.com"), null, emptyList(), "all");
+
+		유저_등록_로그인("target@gmail.com", "GOOGLE");
+		targetProfileId = 프로필_등록("target", List.of("IT"));
+		unsharableBookmarkId = 북마크_등록(링크_메타데이터_얻기("http://www.naver.com"), null, emptyList(), "all");
+		팔로우(senderProfileId);
+	}
+
+	@Test
+	void 공유_알림_생성하고_조회_성공() throws Exception {
+		//given
+		로그인("sender@gmail.com", "GOOGLE");
+		final Map<String, Long> request = Map.of(
+			"targetId", targetProfileId
+		);
+
+		//when
+		//공유 알림 하나 생성
+		mockMvc.perform(post("/api/v1/bookmarks/{bookmarkId}" + "/share", shareBookmarkId)
+				.header(AUTHORIZATION, token)
+				.contentType(APPLICATION_JSON)
+				.content(createJson(request)))
+			//then
+			.andExpect(status().isOk())
+			.andDo(print());
+
+		//when
+		//공유 알림 조회
+		로그인("target@gmail.com", "GOOGLE");
+
+		mockMvc.perform(get(baseUrl)
+				.header(AUTHORIZATION, token)
+				.contentType(APPLICATION_JSON))
+			//then
+			.andExpect(status().isOk())
+			.andExpectAll(
+
+				jsonPath("$.notifications", hasSize(1)),
+				jsonPath("$.notifications[0].info").exists(),
+
+				jsonPath("$.notifications[0].info.sender").exists(),
+				jsonPath("$.notifications[0].info.sender.id").value(senderProfileId),
+				jsonPath("$.notifications[0].info.sender.username").value("sender"),
+
+				jsonPath("$.notifications[0].info.bookmark").exists(),
+				jsonPath("$.notifications[0].info.bookmark.id").value(shareBookmarkId),
+				jsonPath("$.notifications[0].info.bookmark.title").value("title"),
+				jsonPath("$.notifications[0].info.bookmark.link").value("http://www.naver.com")
+			)
+
+			//docs
+			.andDo(
+				restDocs.document(
+					requestHeaders(
+						headerWithName(AUTHORIZATION).description("인증 토큰")
+					),
+					requestParameters(
+						parameterWithName("page").optional().description("현재 페이지(page)"),
+						parameterWithName("size").optional().description("프로필 개수(size)")
+					),
+					responseFields(
+						fieldWithPath("hasNext").optional().description("프로필 리스트"),
+						fieldWithPath("notifications[]").optional().description("프로필 리스트"),
+						fieldWithPath("notifications[].type").description("프로필 ID"),
+						fieldWithPath("notifications[].info").description("유저 이름"),
+						fieldWithPath("notifications[].info").description("유저 이름"),
+						fieldWithPath("notifications[].info.bookmark").description("유저 이름"),
+						fieldWithPath("notifications[].info.bookmark.id").description("유저 이름"),
+						fieldWithPath("notifications[].info.bookmark.title").description("유저 이름"),
+						fieldWithPath("notifications[].info.bookmark.link").description("유저 이름"),
+						fieldWithPath("notifications[].info.sender").description("유저 이름"),
+						fieldWithPath("notifications[].info.sender.id").description("유저 이름"),
+						fieldWithPath("notifications[].info.sender.username").description("유저 이름")
+					)
+				)
+			);
+	}
+
+}

--- a/src/test/java/com/meoguri/linkocean/controller/restdocs/ProfileDocsController.java
+++ b/src/test/java/com/meoguri/linkocean/controller/restdocs/ProfileDocsController.java
@@ -1,0 +1,322 @@
+package com.meoguri.linkocean.controller.restdocs;
+
+import static java.util.Collections.*;
+import static org.hamcrest.Matchers.*;
+import static org.springframework.http.HttpHeaders.*;
+import static org.springframework.http.HttpMethod.*;
+import static org.springframework.http.MediaType.*;
+import static org.springframework.restdocs.headers.HeaderDocumentation.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.net.URI;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
+
+import com.meoguri.linkocean.controller.profile.ProfileController;
+import com.meoguri.linkocean.controller.profile.dto.CreateProfileRequest;
+import com.meoguri.linkocean.controller.support.RestDocsTestSupport;
+
+public class ProfileDocsController extends RestDocsTestSupport {
+
+	private final String baseUrl = getBaseUrl(ProfileController.class);
+
+	@Test
+	void 프로필_등록_api() throws Exception {
+		//given
+		유저_등록_로그인("hani@gmail.com", "GOOGLE");
+		final String username = "hani";
+		final List<String> categories = List.of("인문", "정치", "사회");
+		final CreateProfileRequest createProfileRequest = new CreateProfileRequest(username, categories);
+
+		//when
+		mockMvc.perform(post(baseUrl)
+				.header(AUTHORIZATION, token)
+				.contentType(APPLICATION_JSON)
+				.content(createJson(createProfileRequest)))
+			//then
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.id").exists())
+
+			//docs
+			.andDo(
+				restDocs.document(
+					requestHeaders(
+						headerWithName(AUTHORIZATION).description("인증 토큰")
+					),
+					requestFields(
+						fieldWithPath("username").description("이메일"),
+						fieldWithPath("categories").description("선호 카테고리")
+					),
+					responseFields(
+						fieldWithPath("id").description("프로필 ID")
+					)
+				)
+			);
+	}
+
+	@Test
+	void 내프로필_조회_api() throws Exception {
+		//given
+		유저_등록_로그인("hani@gmail.com", "GOOGLE");
+		프로필_등록("hani", List.of("인문", "정치", "사회"));
+		북마크_등록(링크_메타데이터_얻기("http://www.naver.com"), "인문", List.of("스프링", "Spring Boot"), "private");
+
+		//when
+		mockMvc.perform(get(baseUrl + "/me")
+				.header(AUTHORIZATION, token))
+			//then
+			.andExpect(status().isOk())
+			.andExpectAll(
+				jsonPath("$.profileId").exists(),
+				jsonPath("$.imageUrl").isEmpty(),
+				jsonPath("$.favoriteCategories", hasSize(3)),
+				jsonPath("$.username").value("hani"),
+				jsonPath("$.bio").isEmpty(),
+				jsonPath("$.followerCount").value(0),
+				jsonPath("$.followeeCount").value(0),
+				jsonPath("$.tags", hasSize(2)),
+				jsonPath("$.categories", hasSize(1))
+			)
+
+			//docs
+			.andDo(
+				restDocs.document(
+					requestHeaders(
+						headerWithName(AUTHORIZATION).description("인증 토큰")
+					),
+					responseFields(
+						fieldWithPath("profileId").description("프로필 ID"),
+						fieldWithPath("imageUrl").optional().description("이미지 url"),
+						fieldWithPath("favoriteCategories").description("선호 카테고리"),
+						fieldWithPath("username").description("유저 이름"),
+						fieldWithPath("bio").optional().description("자기 소개"),
+						fieldWithPath("followerCount").description("팔로워 수"),
+						fieldWithPath("followeeCount").description("팔로위 수"),
+						fieldWithPath("isFollow").description("팔로우 여부"),
+						fieldWithPath("tags[]").optional().description("사용자가 작성한 태그 리스트"),
+						fieldWithPath("tags[].tag").optional().description("태그 이름"),
+						fieldWithPath("tags[].count").optional().description("태그를 가진 북마크 수"),
+						fieldWithPath("categories").optional().description("사용자가 작성한 게시글이 존재하는 카테고리")
+					)
+				)
+			);
+	}
+
+	@Test
+	void 다른_사람_프로필_조회_api() throws Exception {
+		//given
+		유저_등록_로그인("user1@gmail.com", "GOOGLE");
+		final long user1ProfileId = 프로필_등록("user1", emptyList());
+
+		유저_등록_로그인("user2@gmail.com", "GOOGLE");
+		final long user2ProfileId = 프로필_등록("user2", emptyList());
+		북마크_등록(링크_메타데이터_얻기("http://www.naver.com"), "인문", List.of("스프링", "Spring Boot"), "all");
+
+		로그인("user1@gmail.com", "GOOGLE");
+		팔로우(user2ProfileId);
+
+		//when
+		mockMvc.perform(RestDocumentationRequestBuilders.get(baseUrl + "/{profileId}", user2ProfileId)
+				.header(AUTHORIZATION, token)
+				.contentType(APPLICATION_JSON))
+
+			//then
+			.andExpect(status().isOk())
+			.andExpectAll(
+				jsonPath("$.isFollow").value(true),
+				jsonPath("$.followerCount").value(1),
+				jsonPath("$.followeeCount").value(0)
+			)
+
+			//docs
+			.andDo(
+				restDocs.document(
+					requestHeaders(
+						headerWithName(AUTHORIZATION).description("인증 토큰")
+					),
+					pathParameters(
+						parameterWithName("profileId").description("프로필 ID")
+					),
+					responseFields(
+						fieldWithPath("profileId").description("프로필 ID"),
+						fieldWithPath("imageUrl").optional().optional().description("이미지 url"),
+						fieldWithPath("favoriteCategories").description("선호 카테고리"),
+						fieldWithPath("username").description("유저 이름"),
+						fieldWithPath("bio").optional().optional().description("자기 소개"),
+						fieldWithPath("followerCount").description("팔로워 수"),
+						fieldWithPath("followeeCount").description("팔로위 수"),
+						fieldWithPath("isFollow").description("팔로우 여부"),
+						fieldWithPath("tags[]").optional().description("팔로우 여부"),
+						fieldWithPath("tags[].tag").optional().description("태그 이름"),
+						fieldWithPath("tags[].count").optional().description("태그를 가진 북마크 수"),
+						fieldWithPath("categories").optional().description("사용자가 작성한 게시글이 있는 카테고리")
+					)
+				)
+			);
+	}
+
+	@Test
+	void 내_프로필_수정_api() throws Exception {
+		//given
+		유저_등록_로그인("hani@gmail.com", "GOOGLE");
+		프로필_등록("hani", List.of("인문", "정치", "사회", "IT"));
+		북마크_등록(링크_메타데이터_얻기("http://www.naver.com"), "인문", List.of("스프링", "Spring Boot"), "private");
+
+		final String updateUsername = "updateHani";
+		final List<String> updateCategories = List.of("자기계발", "과학");
+		final String bio = "i like programming";
+		final MockMultipartFile mockImage = new MockMultipartFile("image", "test.png", "image/png",
+			"image".getBytes());
+
+		//when
+		mockMvc.perform(multipart(PUT, URI.create(baseUrl + "/me"))
+				.file(mockImage)
+				.param("username", updateUsername)
+				.param("categories", "자기계발", "과학")
+				.param("bio", bio)
+				.header(AUTHORIZATION, token))
+			//then
+			.andExpect(status().isOk())
+
+			//docs
+			.andDo(
+				restDocs.document(
+					requestHeaders(
+						headerWithName(AUTHORIZATION).description("인증 토큰")
+					),
+					requestParameters(
+						parameterWithName("username").description("유저 이름"),
+						parameterWithName("categories").description("선호 카테고리"),
+						parameterWithName("bio").optional().description("자기 소개")
+					),
+					requestParts(
+						partWithName("image").optional().description("이미지 파일")
+					)
+				)
+			);
+
+	}
+
+	@Nested
+	class 프로필_목록_조회_시리즈_테스트 {
+		long user1ProfileId;
+		long user2ProfileId;
+		long user3ProfileId;
+
+		@BeforeEach
+		void setUp() throws Exception {
+			유저_등록_로그인("user1@gmail.com", "GOOGLE");
+			user1ProfileId = 프로필_등록("user1", List.of("IT"));
+
+			유저_등록_로그인("user2@gmail.com", "GOOGLE");
+			user2ProfileId = 프로필_등록("user2", List.of("IT"));
+
+			유저_등록_로그인("user3@gmail.com", "GOOGLE");
+			user3ProfileId = 프로필_등록("user3", List.of("IT"));
+
+			// 팔로우 화살표 : user1 <-> user2 -> user3
+			로그인("user1@gmail.com", "GOOGLE");
+			팔로우(user2ProfileId);
+
+			로그인("user2@gmail.com", "GOOGLE");
+			팔로우(user1ProfileId);
+			팔로우(user3ProfileId);
+		}
+
+		@Test
+		void 프로필_목록_조회_api() throws Exception {
+
+			로그인("user1@gmail.com", "GOOGLE");
+
+			mockMvc.perform(get(baseUrl + "?username=" + "user")
+					.header(AUTHORIZATION, token)
+					.contentType(APPLICATION_JSON))
+				.andExpect(status().isOk())
+				.andExpectAll(
+					jsonPath("$.hasNext").value(false),
+					jsonPath("$.profiles").isArray(),
+					jsonPath("$.profiles", hasSize(3)),
+					jsonPath("$.profiles[0].profileId").value(user1ProfileId),
+					jsonPath("$.profiles[1].profileId").value(user2ProfileId),
+					jsonPath("$.profiles[2].profileId").value(user3ProfileId),
+					jsonPath("$.profiles[0].isFollow").value(false),
+					jsonPath("$.profiles[1].isFollow").value(true),
+					jsonPath("$.profiles[2].isFollow").value(false)
+				)
+
+				//docs
+				.andDo(
+					restDocs.document(
+						requestHeaders(
+							headerWithName(AUTHORIZATION).description("인증 토큰")
+						),
+						requestParameters(
+							parameterWithName("page").optional().description("현재 페이지(page)"),
+							parameterWithName("size").optional().description("프로필 개수(size)"),
+							parameterWithName("username").optional().description("유저 JsonFieldType.이름")
+						),
+						responseFields(
+							fieldWithPath("hasNext").description("다음 페이지 존재 여부"),
+							fieldWithPath("profiles[]").optional().description("프로필 리스트"),
+							fieldWithPath("profiles[].profileId").description("프로필 ID"),
+							fieldWithPath("profiles[].username").description("유저 이름"),
+							fieldWithPath("profiles[].imageUrl").optional().description("이미지 URL"),
+							fieldWithPath("profiles[].isFollow").description("팔로우 여부")
+						)
+					)
+				);
+		}
+
+		@Test
+		void 팔로워_조회_Api_성공() throws Exception {
+			로그인("user1@gmail.com", "GOOGLE");
+
+			// user1 -> user1 의 팔로워 조회
+			mockMvc.perform(
+					RestDocumentationRequestBuilders.get(baseUrl + "/{profileId}/{tab}", user1ProfileId, "follower")
+						.header(AUTHORIZATION, token)
+						.contentType(APPLICATION_JSON))
+				.andExpect(status().isOk())
+				.andExpectAll(
+					jsonPath("$.hasNext").value(false),
+					jsonPath("$.profiles", hasSize(1)),
+					jsonPath("$.profiles[0].profileId").value(user2ProfileId),
+					jsonPath("$.profiles[0].isFollow").value(true)
+				)
+
+				//docs
+				.andDo(
+					restDocs.document(
+						requestHeaders(
+							headerWithName(AUTHORIZATION).description("인증 토큰")
+						),
+						pathParameters(
+							parameterWithName("profileId").description("프로필 ID"),
+							parameterWithName("tab").description("팔로우, 팔로위 토클")
+						),
+						requestParameters(
+							parameterWithName("page").optional().description("현재 페이지(page)"),
+							parameterWithName("size").optional().description("프로필 개수(size)"),
+							parameterWithName("username").optional().description("유저 이름")
+						),
+						responseFields(
+							fieldWithPath("hasNext").description("다음 페이지 존재 여부"),
+							fieldWithPath("profiles[]").optional().description("프로필 리스트"),
+							fieldWithPath("profiles[].profileId").description("프로필 ID"),
+							fieldWithPath("profiles[].username").description("유저 이름"),
+							fieldWithPath("profiles[].imageUrl").optional().description("이미지 URL"),
+							fieldWithPath("profiles[].isFollow").description("팔로우 여부")
+						)
+					)
+				);
+		}
+	}
+}


### PR DESCRIPTION
## 🛠️ 작업 내용
- login, follow, notification, linkMetadata, profile restdocs 추가

## 🗨️ 기타
- 처음에 저희 ControllerTest에 바로 RestDocs를 적용하려 했습니다.
- 하지만 적용하려보니 다양한 문제점이 있었습니다. 이 부분에 대해서는 내일 만나서 설명드리겠습니다.
- 따라서 ~DocsController를 만들고 RestDocs 작업을 진행하였습니다.

추가) 저희 API Document 최신화 아주 많이 안되어 있더군요 ㅎㄷㄷ 이걸로 작업하신 프론트엔드가 대단하다 느끼는 하루였습니다 😢 
또 추가) 저희 DocsController는 평소에 Disable하고있다가 docs를 최신화할 때 풀어주는 방식으로 진행해도 될 것 같습니다.

## 😎 리뷰어
@ndy2 ,@NewEgoDoc, @hyuk0309

