### PR TITLE
[LO-157] 링크 메타데이터 제목 조회 API 수정

### DIFF
--- a/src/main/java/com/meoguri/linkocean/controller/linkmetadata/LinkMetadataController.java
+++ b/src/main/java/com/meoguri/linkocean/controller/linkmetadata/LinkMetadataController.java
@@ -3,8 +3,8 @@ package com.meoguri.linkocean.controller.linkmetadata;
 import java.util.Map;
 
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.meoguri.linkocean.domain.linkmetadata.service.LinkMetadataService;
@@ -21,8 +21,8 @@ public class LinkMetadataController {
 	/* 링크 메타데이터 얻기 */
 	@PostMapping("/obtain")
 	public Map<String, Object> getOrSaveLinkMetaTitle(
-		final @RequestParam String link
+		final @RequestBody Map<String, String> request
 	) {
-		return Map.of("title", linkMetadataService.getOrSaveLinkMetadataTitle(link));
+		return Map.of("title", linkMetadataService.getOrSaveLinkMetadataTitle(request.get("url")));
 	}
 }

--- a/src/test/java/com/meoguri/linkocean/controller/linkmetadata/LinkMetadataControllerTest.java
+++ b/src/test/java/com/meoguri/linkocean/controller/linkmetadata/LinkMetadataControllerTest.java
@@ -6,10 +6,10 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import java.util.List;
+import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
-import org.springframework.web.util.UriComponentsBuilder;
 
 import com.meoguri.linkocean.controller.support.BaseControllerTest;
 
@@ -24,20 +24,16 @@ class LinkMetadataControllerTest extends BaseControllerTest {
 		프로필_등록("hani", List.of("정치", "인문", "사회"));
 
 		final String link = "http://www.naver.com";
-		//when
-		mockMvc.perform(post(UriComponentsBuilder.fromUriString(basePath)
-				.pathSegment("obtain")
-				.queryParam("link", link)
-				.build()
-				.toUri())
-				.header(AUTHORIZATION, token)
-				.contentType(MediaType.APPLICATION_JSON))
+		final Map<String, String> request = Map.of("url", link);
 
-			//then
+		//when
+		mockMvc.perform(post(basePath + "/obtain")
+				.header(AUTHORIZATION, token)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(createJson(request)))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.title").exists())
 			.andDo(print());
-
 	}
 
 }


### PR DESCRIPTION
## 🛠️ 작업 내용
- 링크 메타데이터 제목 조회 API 수정

## 🗨️ 기타
<!-- PR 포인트 혹은 궁금한 점 등등 적어주시면 됩니다. 없으시면 지워주세요 -->
- 링크 메타데이터 제목 조회 API에서 문제를 발견했습니다. 
- url을 쿼리 파라미터로 받다보니, url에 `&`가 있으면 뒤에 있는 문자열들이 짤리는 것 같습니다.
- 이를 해결하기 위해서는 url을 쿼리 파라미터가 아니라, request body로 받아야 할 것 같아요. 마침 링크 메타데이터 제목 조회 API도 POST고요!
- (중요!!) 아직 머지하면 안됩니다. 프론트 분들 의견 들어보고 합의되면 머지하겠습니다~

## 😎 리뷰어
@ndy2 , @jk05018 , @NewEgoDoc, @hyuk0309
