### PR TITLE
[LO-158] 링크 메타데이터 저장시 http(s) & www 제거하는 로직 제거하기

### DIFF
--- a/src/main/java/com/meoguri/linkocean/domain/linkmetadata/entity/Link.java
+++ b/src/main/java/com/meoguri/linkocean/domain/linkmetadata/entity/Link.java
@@ -15,7 +15,6 @@ import lombok.NoArgsConstructor;
 /**
  * 링크(Link)
  * - 링크 메타 데이터 테이블의 column 이며 유일하다.
- * - 링크는 저장될 때 schema (http, https) 와 www. 를 지우고 저장한다.
  */
 @Getter
 @NoArgsConstructor(access = PROTECTED)

--- a/src/main/java/com/meoguri/linkocean/domain/linkmetadata/entity/Link.java
+++ b/src/main/java/com/meoguri/linkocean/domain/linkmetadata/entity/Link.java
@@ -38,19 +38,4 @@ public final class Link {
 	public static String toString(final Link link) {
 		return link.getLink();
 	}
-
-	@Deprecated
-	private String removeSchemaAndWwwIfExists(final String link) {
-		return link.replaceFirst("^(http[s]?://www\\.|http[s]?://|www\\.)", "");
-	}
-
-	@Deprecated
-	public String getFullLink() {
-		return "https://www." + this.link;
-	}
-
-	@Deprecated
-	public String getSavedLink() {
-		return this.link;
-	}
 }

--- a/src/main/java/com/meoguri/linkocean/domain/linkmetadata/entity/Link.java
+++ b/src/main/java/com/meoguri/linkocean/domain/linkmetadata/entity/Link.java
@@ -3,10 +3,13 @@ package com.meoguri.linkocean.domain.linkmetadata.entity;
 import static com.meoguri.linkocean.exception.Preconditions.*;
 import static lombok.AccessLevel.*;
 
+import java.util.regex.Pattern;
+
 import javax.persistence.Column;
 import javax.persistence.Embeddable;
 
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 /**
@@ -14,28 +17,39 @@ import lombok.NoArgsConstructor;
  * - 링크 메타 데이터 테이블의 column 이며 유일하다.
  * - 링크는 저장될 때 schema (http, https) 와 www. 를 지우고 저장한다.
  */
+@Getter
 @NoArgsConstructor(access = PROTECTED)
 @EqualsAndHashCode
 @Embeddable
 public final class Link {
 
+	private static final String URL_REGEX = "^((http|https)://)?(www.)?([a-zA-Z0-9]+)\\.[a-z]+([a-zA-z0-9.?#]+)?";
+	private static final Pattern URL_PATTERN = Pattern.compile(URL_REGEX);
+
 	@Column(nullable = false, unique = true, length = 700)
 	private String link;
 
 	public Link(final String link) {
-		checkArgument(link.contains("."), "link 형식이 올바르지 않습니다.");
+		checkArgument(URL_PATTERN.matcher(link).matches(), "link 형식이 올바르지 않습니다.");
 
-		this.link = removeSchemaAndWwwIfExists(link);
+		this.link = link;
 	}
 
+	public static String toString(final Link link) {
+		return link.getLink();
+	}
+
+	@Deprecated
 	private String removeSchemaAndWwwIfExists(final String link) {
 		return link.replaceFirst("^(http[s]?://www\\.|http[s]?://|www\\.)", "");
 	}
 
+	@Deprecated
 	public String getFullLink() {
 		return "https://www." + this.link;
 	}
 
+	@Deprecated
 	public String getSavedLink() {
 		return this.link;
 	}

--- a/src/main/java/com/meoguri/linkocean/domain/linkmetadata/entity/LinkMetadata.java
+++ b/src/main/java/com/meoguri/linkocean/domain/linkmetadata/entity/LinkMetadata.java
@@ -51,12 +51,4 @@ public class LinkMetadata extends BaseIdEntity {
 		this.title = title;
 		this.image = image;
 	}
-
-	public String getFullLink() {
-		return link.getFullLink();
-	}
-
-	public String getSavedLink() {
-		return link.getSavedLink();
-	}
 }

--- a/src/main/java/com/meoguri/linkocean/domain/linkmetadata/service/LinkMetadataServiceImpl.java
+++ b/src/main/java/com/meoguri/linkocean/domain/linkmetadata/service/LinkMetadataServiceImpl.java
@@ -47,7 +47,8 @@ public class LinkMetadataServiceImpl implements LinkMetadataService {
 		final Slice<LinkMetadata> slice = linkMetadataRepository.findBy(pageable);
 		slice.getContent()
 			.forEach(linkMetadata -> {
-				final SearchLinkMetadataResult result = jsoupLinkMetadataService.search(linkMetadata.getFullLink());
+				final SearchLinkMetadataResult result = jsoupLinkMetadataService.search(
+					Link.toString(linkMetadata.getLink()));
 				linkMetadata.update(result.getTitle(), result.getImage());
 			});
 		return slice.hasNext() ? slice.nextPageable() : null;

--- a/src/test/java/com/meoguri/linkocean/domain/bookmark/persistence/BookmarkRepositoryTest.java
+++ b/src/test/java/com/meoguri/linkocean/domain/bookmark/persistence/BookmarkRepositoryTest.java
@@ -23,6 +23,7 @@ import com.meoguri.linkocean.common.CustomP6spySqlFormat;
 import com.meoguri.linkocean.domain.bookmark.entity.Bookmark;
 import com.meoguri.linkocean.domain.bookmark.entity.Tag;
 import com.meoguri.linkocean.domain.bookmark.entity.vo.Category;
+import com.meoguri.linkocean.domain.linkmetadata.entity.Link;
 import com.meoguri.linkocean.domain.linkmetadata.entity.LinkMetadata;
 import com.meoguri.linkocean.domain.linkmetadata.persistence.LinkMetadataRepository;
 import com.meoguri.linkocean.domain.profile.entity.Profile;
@@ -56,7 +57,7 @@ class BookmarkRepositoryTest {
 	private TagRepository tagRepository;
 
 	private Profile profile;
-	private LinkMetadata link;
+	private LinkMetadata linkMetadata;
 	private Tag tag1;
 	private Tag tag2;
 	private Tag tag3;
@@ -66,7 +67,7 @@ class BookmarkRepositoryTest {
 		// 프로필, 링크 셋업
 		User user = userRepository.save(createUser());
 		profile = profileRepository.save(createProfile(user));
-		link = linkMetadataRepository.save(createLinkMetadata());
+		linkMetadata = linkMetadataRepository.save(createLinkMetadata());
 
 		// 태그 셋업
 		tag1 = tagRepository.save(new Tag("tag1"));
@@ -77,7 +78,7 @@ class BookmarkRepositoryTest {
 	@Test
 	void 프로필_url_이용한_북마크_조회() {
 		//given
-		final Bookmark bookmark = createBookmark(profile, link);
+		final Bookmark bookmark = createBookmark(profile, linkMetadata);
 		bookmarkRepository.save(bookmark);
 
 		//when
@@ -91,7 +92,7 @@ class BookmarkRepositoryTest {
 	@Test
 	void 프로필_북마크_아이디_이용한_북마크_조회() {
 		//given
-		final Bookmark bookmark = createBookmark(profile, link);
+		final Bookmark bookmark = createBookmark(profile, linkMetadata);
 		final Bookmark savedBookmark = bookmarkRepository.save(bookmark);
 
 		//when
@@ -106,11 +107,11 @@ class BookmarkRepositoryTest {
 	@Test
 	void 사용자의_전체_북마크조회_태그_까지_페치_성공() {
 		//given
-		final Bookmark bookmark1 = createBookmark(profile, link, "bookmark1", IT, "www.naver.com",
+		final Bookmark bookmark1 = createBookmark(profile, linkMetadata, "bookmark1", IT, "www.naver.com",
 			List.of(tag1, tag2, tag3));
-		final Bookmark bookmark2 = createBookmark(profile, link, "bookmark2", IT, "www.google.com",
+		final Bookmark bookmark2 = createBookmark(profile, linkMetadata, "bookmark2", IT, "www.google.com",
 			List.of(tag2, tag3));
-		final Bookmark bookmark3 = createBookmark(profile, link, "bookmark3", IT, "www.haha.com",
+		final Bookmark bookmark3 = createBookmark(profile, linkMetadata, "bookmark3", IT, "www.haha.com",
 			List.of(tag3));
 
 		bookmarkRepository.save(bookmark1);
@@ -140,7 +141,7 @@ class BookmarkRepositoryTest {
 	void 북마크와_연관관계_맺은_엔티티_페치_조인_이용해_같이_조회() {
 		//given
 		final Bookmark bookmark = bookmarkRepository.save(
-			createBookmark(profile, link, "title", ART, link.getFullLink(), List.of(tag1)));
+			createBookmark(profile, linkMetadata, "title", ART, Link.toString(linkMetadata.getLink()), List.of(tag1)));
 
 		em.flush();
 		em.clear();
@@ -165,12 +166,12 @@ class BookmarkRepositoryTest {
 	@Test
 	void 게시글이_존재하는_카테고리이름_반환() {
 		//given
-		bookmarkRepository.save(createBookmark(profile, link, "제목", IT, "www.google.com"));
-		bookmarkRepository.save(createBookmark(profile, link, "제목", IT, "www.naver.com"));
-		bookmarkRepository.save(createBookmark(profile, link, "제목", IT, "www.prgrms.com"));
-		bookmarkRepository.save(createBookmark(profile, link, "제목", SOCIAL, "www.daum.com"));
-		bookmarkRepository.save(createBookmark(profile, link, "제목", SOCIAL, "www.hello.com"));
-		bookmarkRepository.save(createBookmark(profile, link, "제목", SCIENCE, "www.linkocean.com"));
+		bookmarkRepository.save(createBookmark(profile, linkMetadata, "제목", IT, "www.google.com"));
+		bookmarkRepository.save(createBookmark(profile, linkMetadata, "제목", IT, "www.naver.com"));
+		bookmarkRepository.save(createBookmark(profile, linkMetadata, "제목", IT, "www.prgrms.com"));
+		bookmarkRepository.save(createBookmark(profile, linkMetadata, "제목", SOCIAL, "www.daum.com"));
+		bookmarkRepository.save(createBookmark(profile, linkMetadata, "제목", SOCIAL, "www.hello.com"));
+		bookmarkRepository.save(createBookmark(profile, linkMetadata, "제목", SCIENCE, "www.linkocean.com"));
 
 		//when
 		final List<Category> categories = bookmarkRepository.findCategoryExistsBookmark(profile);
@@ -183,7 +184,7 @@ class BookmarkRepositoryTest {
 	void 프로필_아이디_url_로_북마크_존재하는지_확인_성공() {
 		//given
 		final Bookmark bookmark =
-			bookmarkRepository.save(createBookmark(profile, link, "제목", IT, "https://www.google.com"));
+			bookmarkRepository.save(createBookmark(profile, linkMetadata, "제목", IT, "https://www.google.com"));
 
 		//when
 		final Optional<Long> oBookmarkId1 =
@@ -200,7 +201,7 @@ class BookmarkRepositoryTest {
 	void 북마크_LikeCount_증가_성공() {
 		//given
 		final Bookmark bookmark =
-			bookmarkRepository.save(createBookmark(profile, link, "제목", Category.IT, "https://www.google.com"));
+			bookmarkRepository.save(createBookmark(profile, linkMetadata, "제목", Category.IT, "https://www.google.com"));
 
 		//when
 		bookmarkRepository.addLikeCount(bookmark.getId());

--- a/src/test/java/com/meoguri/linkocean/domain/bookmark/service/BookmarkServiceImplTest.java
+++ b/src/test/java/com/meoguri/linkocean/domain/bookmark/service/BookmarkServiceImplTest.java
@@ -41,6 +41,7 @@ import com.meoguri.linkocean.domain.bookmark.service.dto.GetDetailedBookmarkResu
 import com.meoguri.linkocean.domain.bookmark.service.dto.GetFeedBookmarksResult;
 import com.meoguri.linkocean.domain.bookmark.service.dto.RegisterBookmarkCommand;
 import com.meoguri.linkocean.domain.bookmark.service.dto.UpdateBookmarkCommand;
+import com.meoguri.linkocean.domain.linkmetadata.entity.Link;
 import com.meoguri.linkocean.domain.linkmetadata.entity.LinkMetadata;
 import com.meoguri.linkocean.domain.linkmetadata.persistence.LinkMetadataRepository;
 import com.meoguri.linkocean.domain.profile.entity.Follow;
@@ -103,7 +104,7 @@ class BookmarkServiceImplTest {
 
 		linkMetadata = linkMetadataRepository.save(createLinkMetadata());
 
-		url = linkMetadata.getSavedLink(); // 조회를 위해서는 저장된 url 이 필요하다
+		url = Link.toString(linkMetadata.getLink()); // 조회를 위해서는 저장된 url 이 필요하다
 	}
 
 	@Nested
@@ -475,7 +476,7 @@ class BookmarkServiceImplTest {
 
 			final RegisterBookmarkCommand command2 = new RegisterBookmarkCommand(
 				profileId2,
-				"http://www.kakao.com",
+				"http://www.daum.com",
 				"title2",
 				null,
 				IT,
@@ -485,7 +486,7 @@ class BookmarkServiceImplTest {
 
 			final RegisterBookmarkCommand command3 = new RegisterBookmarkCommand(
 				profileId2,
-				"http://www.google.com",
+				"http://www.kakao.com",
 				"title3",
 				null,
 				HOME,

--- a/src/test/java/com/meoguri/linkocean/domain/bookmark/service/FavoriteServiceImplTest.java
+++ b/src/test/java/com/meoguri/linkocean/domain/bookmark/service/FavoriteServiceImplTest.java
@@ -53,7 +53,7 @@ class FavoriteServiceImplTest {
 		profileId = profileService.registerProfile(command(createProfile(user)));
 
 		linkMetadataService.getOrSaveLinkMetadataTitle("https://www.naver.com");
-		bookmarkId = bookmarkService.registerBookmark(command(user, "www.naver.com"));
+		bookmarkId = bookmarkService.registerBookmark(command(user, "https://www.naver.com"));
 	}
 
 	@Test

--- a/src/test/java/com/meoguri/linkocean/domain/linkmetadata/entity/LinkTest.java
+++ b/src/test/java/com/meoguri/linkocean/domain/linkmetadata/entity/LinkTest.java
@@ -9,7 +9,15 @@ import org.junit.jupiter.params.provider.ValueSource;
 class LinkTest {
 
 	@ParameterizedTest
-	@ValueSource(strings = {"http://www.naver.com", "www.naver.com"})
+	@ValueSource(
+		strings = {
+			"http://www.naver.com",
+			"https://www.naver.com",
+			"www.naver.com",
+			"naver.com",
+			"dev.naver.com"
+		}
+	)
 	void url_생성_성공(final String textUrl) {
 		//when
 		final Link link = new Link(textUrl);

--- a/src/test/java/com/meoguri/linkocean/domain/linkmetadata/persistence/FindLinkMetadataByLinkQueryTest.java
+++ b/src/test/java/com/meoguri/linkocean/domain/linkmetadata/persistence/FindLinkMetadataByLinkQueryTest.java
@@ -9,6 +9,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 
+import com.meoguri.linkocean.domain.linkmetadata.entity.Link;
 import com.meoguri.linkocean.domain.linkmetadata.entity.LinkMetadata;
 
 @Import(FindLinkMetadataByUrlQuery.class)
@@ -28,7 +29,7 @@ class FindLinkMetadataByLinkQueryTest {
 
 		//when
 		final LinkMetadata findLinkMetadata =
-			findLinkMetadataByUrlQuery.findByUrl(linkMetadata.getSavedLink());
+			findLinkMetadataByUrlQuery.findByUrl(Link.toString(linkMetadata.getLink()));
 
 		//then
 		assertThat(findLinkMetadata).isEqualTo(linkMetadata);


### PR DESCRIPTION
## 🛠️ 작업 내용
- 링크 메타데이터 저장시 http(s) & www 제거하는 로직 제거하기

## 🗨️ 기타
<!-- PR 포인트 혹은 궁금한 점 등등 적어주시면 됩니다. 없으시면 지워주세요 -->
-  기존에는 linkmetadata의 link 저장 과정에서 입력 받은 link를  그대로 저장하는게 아니라 http(s) & www를 제거하고 저장했습니다.
-  처음에는 위 로직이 데이터 중복을 줄여 좋을지 알았는데, link에 너무 많은 경우의 수가 있어 버그가 생겼습니다.
-  따라서 데이터를 전처리하지 않고 그대로 저장하는 방식으로 수정했습니다.

## 😎 리뷰어
@ndy2 , @jk05018 , @NewEgoDoc, @hyuk0309
