### PR TITLE
[LO-181] 북마크 목록 조회 카운트 쿼리 최적화

### DIFF
--- a/src/main/java/com/meoguri/linkocean/domain/bookmark/persistence/CustomBookmarkRepositoryImpl.java
+++ b/src/main/java/com/meoguri/linkocean/domain/bookmark/persistence/CustomBookmarkRepositoryImpl.java
@@ -3,7 +3,7 @@ package com.meoguri.linkocean.domain.bookmark.persistence;
 import static com.meoguri.linkocean.domain.bookmark.entity.QBookmark.*;
 import static com.meoguri.linkocean.domain.bookmark.entity.QBookmarkTag.*;
 import static com.meoguri.linkocean.domain.profile.entity.QFollow.*;
-import static com.meoguri.linkocean.util.JoinInfoBuilder.Initializer.*;
+import static com.meoguri.linkocean.util.querydsl.JoinInfoBuilder.Initializer.*;
 import static org.apache.commons.lang3.BooleanUtils.*;
 
 import java.util.ArrayList;
@@ -20,7 +20,8 @@ import com.meoguri.linkocean.domain.bookmark.entity.vo.BookmarkStatus;
 import com.meoguri.linkocean.domain.bookmark.entity.vo.Category;
 import com.meoguri.linkocean.domain.bookmark.entity.vo.OpenType;
 import com.meoguri.linkocean.domain.bookmark.persistence.dto.BookmarkFindCond;
-import com.meoguri.linkocean.util.Querydsl4RepositorySupport;
+import com.meoguri.linkocean.util.querydsl.CustomPath;
+import com.meoguri.linkocean.util.querydsl.Querydsl4RepositorySupport;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
@@ -107,9 +108,9 @@ public class CustomBookmarkRepositoryImpl extends Querydsl4RepositorySupport imp
 
 	private List<Long> getFavoriteBookmarkIds(final boolean isFavorite, final long profileId) {
 		return !isFavorite ? null : getJpasqlQuery()
-			.select(bookmarkId)
-			.from(favorite)
-			.where(ownerId.eq(profileId))
+			.select(CustomPath.bookmarkId)
+			.from(CustomPath.favorite)
+			.where(CustomPath.profileId.eq(profileId))
 			.fetch();
 	}
 

--- a/src/main/java/com/meoguri/linkocean/domain/profile/persistence/CustomProfileRepositoryImpl.java
+++ b/src/main/java/com/meoguri/linkocean/domain/profile/persistence/CustomProfileRepositoryImpl.java
@@ -2,7 +2,7 @@ package com.meoguri.linkocean.domain.profile.persistence;
 
 import static com.meoguri.linkocean.domain.profile.entity.QFollow.*;
 import static com.meoguri.linkocean.domain.profile.entity.QProfile.*;
-import static com.meoguri.linkocean.util.JoinInfoBuilder.Initializer.*;
+import static com.meoguri.linkocean.util.querydsl.JoinInfoBuilder.Initializer.*;
 
 import javax.persistence.EntityManager;
 
@@ -12,7 +12,7 @@ import org.springframework.stereotype.Repository;
 
 import com.meoguri.linkocean.domain.profile.entity.Profile;
 import com.meoguri.linkocean.domain.profile.persistence.dto.ProfileFindCond;
-import com.meoguri.linkocean.util.Querydsl4RepositorySupport;
+import com.meoguri.linkocean.util.querydsl.Querydsl4RepositorySupport;
 import com.querydsl.core.BooleanBuilder;
 
 @Repository

--- a/src/main/java/com/meoguri/linkocean/util/querydsl/CustomPath.java
+++ b/src/main/java/com/meoguri/linkocean/util/querydsl/CustomPath.java
@@ -1,0 +1,23 @@
+package com.meoguri.linkocean.util.querydsl;
+
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.NumberPath;
+import com.querydsl.sql.RelationalPathBase;
+
+import lombok.NoArgsConstructor;
+
+/* Entity 가 아닌 대상으로 쿼리 하기 위한 Custom Path */
+@NoArgsConstructor
+public final class CustomPath {
+
+	/* favorite f */
+	public static RelationalPathBase<Object> favorite = new RelationalPathBase<>(Object.class, "f", "linkocean",
+		"favorite");
+
+	/* f.owner_id */
+	public static NumberPath<Long> profileId = Expressions.numberPath(Long.class, favorite, "owner_id");
+
+	/* f.bookmark_id */
+	public static NumberPath<Long> bookmarkId = Expressions.numberPath(Long.class, favorite, "bookmark_id");
+
+}

--- a/src/main/java/com/meoguri/linkocean/util/querydsl/Join.java
+++ b/src/main/java/com/meoguri/linkocean/util/querydsl/Join.java
@@ -1,4 +1,4 @@
-package com.meoguri.linkocean.util;
+package com.meoguri.linkocean.util.querydsl;
 
 import java.util.List;
 

--- a/src/main/java/com/meoguri/linkocean/util/querydsl/JoinInfoBuilder.java
+++ b/src/main/java/com/meoguri/linkocean/util/querydsl/JoinInfoBuilder.java
@@ -1,14 +1,20 @@
 package com.meoguri.linkocean.util.querydsl;
 
+import static com.meoguri.linkocean.util.querydsl.Querydsl4RepositorySupport.*;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.function.Supplier;
 
 import com.querydsl.core.types.CollectionExpression;
 import com.querydsl.core.types.EntityPath;
 import com.querydsl.core.types.MapExpression;
 import com.querydsl.core.types.Path;
 import com.querydsl.core.types.Predicate;
+import com.querydsl.jpa.impl.JPAQuery;
+
+import lombok.AllArgsConstructor;
 
 /**
  * 동적 Join 을 제공하기 위한 클래스
@@ -17,8 +23,7 @@ import com.querydsl.core.types.Predicate;
 public class JoinInfoBuilder {
 
 	// join 목록
-	List<Join> joinList = new ArrayList<>();
-
+	final List<Join> joinList = new ArrayList<>();
 
 	private static JoinInfoBuilder builder() {
 		return new JoinInfoBuilder();
@@ -99,4 +104,13 @@ public class JoinInfoBuilder {
 		return this;
 	}
 
+	@AllArgsConstructor
+	public static class JoinIf {
+		final boolean expression;
+		final Supplier<JoinInfoBuilder> joinInfo;
+
+		<T> JPAQuery<T> apply(final JPAQuery<T> query) {
+			return expression ? joinIf(true, query, joinInfo) : query;
+		}
+	}
 }

--- a/src/main/java/com/meoguri/linkocean/util/querydsl/JoinInfoBuilder.java
+++ b/src/main/java/com/meoguri/linkocean/util/querydsl/JoinInfoBuilder.java
@@ -1,4 +1,4 @@
-package com.meoguri.linkocean.util;
+package com.meoguri.linkocean.util.querydsl;
 
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/src/main/java/com/meoguri/linkocean/util/querydsl/Querydsl4RepositorySupport.java
+++ b/src/main/java/com/meoguri/linkocean/util/querydsl/Querydsl4RepositorySupport.java
@@ -1,4 +1,4 @@
-package com.meoguri.linkocean.util;
+package com.meoguri.linkocean.util.querydsl;
 
 import java.util.List;
 import java.util.function.Consumer;
@@ -25,15 +25,12 @@ import com.querydsl.core.types.EntityPath;
 import com.querydsl.core.types.Expression;
 import com.querydsl.core.types.Predicate;
 import com.querydsl.core.types.dsl.BooleanExpression;
-import com.querydsl.core.types.dsl.Expressions;
-import com.querydsl.core.types.dsl.NumberPath;
 import com.querydsl.core.types.dsl.PathBuilder;
 import com.querydsl.jpa.JPQLQuery;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.querydsl.jpa.sql.JPASQLQuery;
 import com.querydsl.sql.MySQLTemplates;
-import com.querydsl.sql.RelationalPathBase;
 import com.querydsl.sql.SQLTemplates;
 
 /**
@@ -44,12 +41,6 @@ import com.querydsl.sql.SQLTemplates;
  */
 @Repository
 public abstract class Querydsl4RepositorySupport {
-
-	protected static RelationalPathBase<Object> favorite = new RelationalPathBase<>(Object.class, "f", "linkocean",
-		"favorite");
-	protected static NumberPath<Long> ownerId = Expressions.numberPath(Long.class, favorite, "owner_id");
-
-	protected static NumberPath<Long> bookmarkId = Expressions.numberPath(Long.class, favorite, "bookmark_id");
 
 	private final Class<?> domainClass;
 

--- a/src/main/java/com/meoguri/linkocean/util/querydsl/Querydsl4RepositorySupport.java
+++ b/src/main/java/com/meoguri/linkocean/util/querydsl/Querydsl4RepositorySupport.java
@@ -81,6 +81,9 @@ public abstract class Querydsl4RepositorySupport {
 		Assert.notNull(queryFactory, "QueryFactory must not be null!");
 	}
 
+	/* 동적 쿼리에 대한 페이징 적용
+	- group by, having 등의 문제가 될 수 있는 쿼리를 사용하지 않기 때문에 JPAQuery.fetchCount 사용 */
+	@SuppressWarnings("deprecation")
 	protected <T> Page<T> applyPagination(
 		final Pageable pageable,
 		JPAQuery<T> contentQuery,
@@ -144,7 +147,10 @@ public abstract class Querydsl4RepositorySupport {
 		return new JoinInfoBuilder.JoinIf(expression, joinInfoBuilder);
 	}
 
-	/* 동적 join 을 지원하기 위한 유틸리티 메서드 */
+	/* 동적 join 을 지원하기 위한 유틸리티 메서드
+	- 각 JoinInfo 에 제네릭을 적용하니 외부에서 타입 추론이 제대로 되지 않아
+	  SubQueryExpression 를 QueryBase 로 처리하는 문제가 생겨 로 타입을 사용 */
+	@SuppressWarnings("unchecked")
 	public static <T> JPAQuery<T> joinIf(
 		final boolean expression,
 		JPAQuery<T> base,

--- a/src/main/java/com/meoguri/linkocean/util/querydsl/Querydsl4RepositorySupport.java
+++ b/src/main/java/com/meoguri/linkocean/util/querydsl/Querydsl4RepositorySupport.java
@@ -37,8 +37,6 @@ import com.querydsl.sql.SQLTemplates;
 
 /**
  * Querydsl 4.x 버전에 맞춘 Querydsl 지원 라이브러리
- *
- * @author Younghan Kim - 인프런 김영한 - 실전! Querydsl! 강의에서 소개한 코드를 활용 하였습니다
  * @see org.springframework.data.jpa.repository.support.QuerydslRepositorySupport
  */
 @Repository
@@ -83,16 +81,32 @@ public abstract class Querydsl4RepositorySupport {
 		Assert.notNull(queryFactory, "QueryFactory must not be null!");
 	}
 
-	protected <T> JPAQuery<T> select(final Expression<T> expr) {
-		return queryFactory.select(expr);
-	}
+	protected <T> Page<T> applyPagination(
+		final Pageable pageable,
+		JPAQuery<T> contentQuery,
+		final List<JoinInfoBuilder.JoinIf> joinIfs,
+		final List<Predicate> where,
+		final Consumer<T> lazyLoader
+	) {
+		final JPAQuery<T> countQuery = contentQuery.clone(entityManager);
+		final Predicate[] whereArray = where.toArray(new Predicate[0]);
 
-	protected <T> JPAQuery<T> selectFrom(final EntityPath<T> from) {
-		return queryFactory.selectFrom(from);
+		/* content query 에 join 과 where 적용 */
+		for (JoinInfoBuilder.JoinIf joinIf : joinIfs) {
+			contentQuery = joinIf.apply(contentQuery);
+		}
+		contentQuery = contentQuery.where(whereArray);
+
+		/* 페이징 적용 후 레이지 로딩 하여 content 완성 */
+		List<T> content = querydsl.applyPagination(pageable, contentQuery).fetch();
+		content.forEach(lazyLoader);
+
+		/* content query 에는 where 만 적용 */
+		countQuery.where(whereArray);
+		return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchCount);
 	}
 
 	/* 무한 스크롤 전용 슬라이싱 */
-
 	protected <T> Slice<T> applySlicing(
 		final Pageable pageable,
 		final JPAQuery<T> jpaContentQuery
@@ -110,17 +124,27 @@ public abstract class Querydsl4RepositorySupport {
 
 		return new SliceImpl<>(content, pageable, hasNext);
 	}
-	/* 동적 where 절을 지원하기 위한 유틸리티 메서드 */
 
-	protected static BooleanBuilder nullSafeBuilder(final Supplier<BooleanExpression> cond) {
-		try {
-			return new BooleanBuilder(cond.get());
-		} catch (IllegalArgumentException | NullPointerException e) {
-			return new BooleanBuilder();
-		}
+	protected <T> JPAQuery<T> select(final Expression<T> expr) {
+		return queryFactory.select(expr);
 	}
-	/* 동적 join 을 지원하기 위한 유틸리티 메서드 */
 
+	protected <T> JPAQuery<T> selectFrom(final EntityPath<T> from) {
+		return queryFactory.selectFrom(from);
+	}
+
+	public List<JoinInfoBuilder.JoinIf> joinIfs(JoinInfoBuilder.JoinIf... joinIfs) {
+		return Arrays.stream(joinIfs).collect(toList());
+	}
+
+	protected JoinInfoBuilder.JoinIf joinIf(
+		final boolean expression,
+		final Supplier<JoinInfoBuilder> joinInfoBuilder
+	) {
+		return new JoinInfoBuilder.JoinIf(expression, joinInfoBuilder);
+	}
+
+	/* 동적 join 을 지원하기 위한 유틸리티 메서드 */
 	public static <T> JPAQuery<T> joinIf(
 		final boolean expression,
 		JPAQuery<T> base,
@@ -156,55 +180,18 @@ public abstract class Querydsl4RepositorySupport {
 		return base;
 	}
 
-	protected JoinInfoBuilder.JoinIf joinIf(
-		final boolean expression,
-		final Supplier<JoinInfoBuilder> joinInfoBuilder
-	) {
-		return new JoinInfoBuilder.JoinIf(expression, joinInfoBuilder);
-	}
-
-	protected <T> Page<T> applyPagination(
-		final Pageable pageable,
-		final JPAQuery<T> jpaContentQuery,
-		final Consumer<T> lazyLoader,
-		final JPAQuery<T> jpaCountQuery
-	) {
-		List<T> content = querydsl.applyPagination(pageable, jpaContentQuery).fetch();
-		content.forEach(lazyLoader);
-		return PageableExecutionUtils.getPage(content, pageable, jpaCountQuery::fetchCount);
-	}
-
-	protected <T> Page<T> applyPagination(
-		final Pageable pageable,
-		JPAQuery<T> contentQuery,
-		final List<JoinInfoBuilder.JoinIf> joinIfs,
-		final List<Predicate> where,
-		final Consumer<T> lazyLoader
-	) {
-		final JPAQuery<T> countQuery = contentQuery.clone(entityManager);
-		final Predicate[] whereArray = where.toArray(new Predicate[0]);
-
-		/* content query 에 join 과 where 적용 */
-		for (JoinInfoBuilder.JoinIf joinIf : joinIfs) {
-			contentQuery = joinIf.apply(contentQuery);
-		}
-		contentQuery = contentQuery.where(whereArray);
-
-		/* 페이징 적용 후 레이지 로딩 하여 content 완성 */
-		List<T> content = querydsl.applyPagination(pageable, contentQuery).fetch();
-		content.forEach(lazyLoader);
-
-		/* content query 에는 where 만 적용 */
-		countQuery.where(whereArray);
-		return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchCount);
-	}
-
-	public List<JoinInfoBuilder.JoinIf> joinIfs(JoinInfoBuilder.JoinIf... joinIfs) {
-		return Arrays.stream(joinIfs).collect(toList());
-	}
-
 	protected List<Predicate> where(Predicate... where) {
 		return Arrays.stream(where).collect(toList());
 	}
+
+	/* 동적 where 절을 지원하기 위한 유틸리티 메서드 */
+	protected static BooleanBuilder nullSafeBuilder(final Supplier<BooleanExpression> cond) {
+		try {
+			return new BooleanBuilder(cond.get());
+		} catch (IllegalArgumentException | NullPointerException e) {
+			return new BooleanBuilder();
+		}
+	}
+
 }
 

--- a/src/test/java/com/meoguri/linkocean/domain/bookmark/persistence/CustomBookmarkRepositoryImplTest.java
+++ b/src/test/java/com/meoguri/linkocean/domain/bookmark/persistence/CustomBookmarkRepositoryImplTest.java
@@ -411,6 +411,26 @@ class CustomBookmarkRepositoryImplTest extends BasePersistenceTest {
 				.containsExactly(bookmark3, bookmark2);
 			assertThat(bookmarkPage.getTotalElements()).isEqualTo(3);
 		}
+
+		/* 카운트 쿼리 최적화 확인 */
+		@Test
+		void 북마크_조회_성공_카테고리_페이징() {
+			//given
+			final BookmarkFindCond findCond = BookmarkFindCond.builder()
+				.currentUserProfileId(profileId)
+				.targetProfileId(profileId)
+				.category(IT)
+				.build();
+			final Pageable pageable = PageRequest.of(0, 2, Sort.by("upload"));
+
+			//when
+			final Page<Bookmark> bookmarkPage = bookmarkRepository.findByTargetProfileId(findCond, pageable);
+
+			//then
+			assertThat(bookmarkPage).hasSize(2);
+			assertThat(bookmarkPage.getContent()).containsExactly(bookmark3, bookmark1);
+			assertThat(bookmarkPage.getTotalElements()).isEqualTo(2);
+		}
 	}
 
 	@Nested

--- a/src/test/java/com/meoguri/linkocean/domain/bookmark/persistence/CustomBookmarkRepositoryImplTest.java
+++ b/src/test/java/com/meoguri/linkocean/domain/bookmark/persistence/CustomBookmarkRepositoryImplTest.java
@@ -16,7 +16,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
-import org.springframework.test.context.TestPropertySource;
 
 import com.meoguri.linkocean.domain.bookmark.entity.Bookmark;
 import com.meoguri.linkocean.domain.bookmark.entity.Tag;
@@ -25,9 +24,6 @@ import com.meoguri.linkocean.domain.linkmetadata.entity.LinkMetadata;
 import com.meoguri.linkocean.domain.profile.entity.Profile;
 import com.meoguri.linkocean.test.support.persistence.BasePersistenceTest;
 
-@TestPropertySource(properties = {
-	"logging.level.org.springframework.orm.jpa=DEBUG"}
-)
 class CustomBookmarkRepositoryImplTest extends BasePersistenceTest {
 
 	@Autowired


### PR DESCRIPTION
<!-- PR 제목 양식 예시: [LO-N] 회원 기능 도메인 -->

## 🛠️ 작업 내용
- 북마크 목록 조회 카운트 쿼리 최적화
- count query 에 대해서 join 을 날리지 않도록 바꾸었습니다.
  단순하게 바꾸면 코드 중복이 심해질 것 같아서 applyPaganation 을 좀 더 커스터마이징 했습니다.
  이제 코드가 훨씬 더 sql 같이 읽히고 볼만해 졌습니다 !

## 😎 리뷰어
@ndy2 , @jk05018 , @NewEgoDoc, @hyuk0309