### PR TITLE
[LO-182] WIP @Entity 북마크.리액션 deprecation -> @ElementCollection 프로필.리액션

### DIFF
--- a/src/main/java/com/meoguri/linkocean/domain/bookmark/entity/Reaction.java
+++ b/src/main/java/com/meoguri/linkocean/domain/bookmark/entity/Reaction.java
@@ -24,6 +24,7 @@ import lombok.NoArgsConstructor;
  * - 리액션 타입은 LIKE/HATE 둘 중 하나이다.
  * - 사용자는 북마크의 리액션을 변경할 수 있다.
  */
+@Deprecated
 @Getter
 @NoArgsConstructor(access = PROTECTED)
 @Entity

--- a/src/main/java/com/meoguri/linkocean/domain/bookmark/persistence/CustomBookmarkRepository.java
+++ b/src/main/java/com/meoguri/linkocean/domain/bookmark/persistence/CustomBookmarkRepository.java
@@ -1,9 +1,12 @@
 package com.meoguri.linkocean.domain.bookmark.persistence;
 
+import java.util.Map;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 import com.meoguri.linkocean.domain.bookmark.entity.Bookmark;
+import com.meoguri.linkocean.domain.bookmark.entity.vo.ReactionType;
 import com.meoguri.linkocean.domain.bookmark.persistence.dto.BookmarkFindCond;
 
 public interface CustomBookmarkRepository {
@@ -14,4 +17,6 @@ public interface CustomBookmarkRepository {
 	/* 피드 북마크 조회 */
 	Page<Bookmark> findBookmarks(BookmarkFindCond findCond, Pageable pageable);
 
+	/* 북마크의 리액션 별 카운트 조회 */
+	Map<ReactionType, Long> countReactionGroup(long bookmarkId);
 }

--- a/src/main/java/com/meoguri/linkocean/domain/bookmark/persistence/ReactionQuery.java
+++ b/src/main/java/com/meoguri/linkocean/domain/bookmark/persistence/ReactionQuery.java
@@ -19,17 +19,6 @@ public class ReactionQuery {
 
 	private final ReactionRepository reactionRepository;
 
-	/* 북마크의 리액션별 카운트 조회 */
-	public Map<ReactionType, Long> getReactionCountMap(Bookmark bookmark) {
-		final Map<ReactionType, Long> reactionCountMap = reactionRepository.countReactionGroup(bookmark);
-
-		Arrays.stream(ReactionType.values())
-			.filter(reactionType -> !reactionCountMap.containsKey(reactionType))
-			.forEach(reactionType -> reactionCountMap.put(reactionType, 0L));
-
-		return reactionCountMap;
-	}
-
 	/* profile 의 bookmark 에 대한 리액션 여부 */
 	public Map<ReactionType, Boolean> getReactionMap(final long profileId, final Bookmark bookmark) {
 		final Optional<Reaction> oReaction = reactionRepository.findByProfile_idAndBookmark(profileId, bookmark);

--- a/src/main/java/com/meoguri/linkocean/domain/bookmark/persistence/ReactionRepository.java
+++ b/src/main/java/com/meoguri/linkocean/domain/bookmark/persistence/ReactionRepository.java
@@ -17,13 +17,6 @@ import com.meoguri.linkocean.domain.bookmark.entity.vo.ReactionType;
 
 public interface ReactionRepository extends JpaRepository<Reaction, Long> {
 
-	@Modifying(clearAutomatically = true)
-	@Query("delete "
-		+ "from Reaction r "
-		+ "where r.profile.id = :profileId "
-		+ "and r.bookmark.id = :bookmarkId")
-	void deleteByProfile_idAndBookmark_id(long profileId, long bookmarkId);
-
 	Optional<Reaction> findByProfile_idAndBookmark(long profileId, Bookmark bookmark);
 
 	@Query("select r.type as type, count(r) as cnt "

--- a/src/main/java/com/meoguri/linkocean/domain/bookmark/service/BookmarkService.java
+++ b/src/main/java/com/meoguri/linkocean/domain/bookmark/service/BookmarkService.java
@@ -40,5 +40,5 @@ public interface BookmarkService {
 	Optional<Long> getBookmarkIdIfExist(long profileId, String url);
 
 	/* 좋아요 숫자 업데이트 */
-	void updateLikeCount(long bookmarkId, boolean isAlreadyReacted, ReactionType existedType, ReactionType requestType);
+	void updateLikeCount(long bookmarkId, ReactionType existedType, ReactionType requestType);
 }

--- a/src/main/java/com/meoguri/linkocean/domain/bookmark/service/BookmarkServiceImpl.java
+++ b/src/main/java/com/meoguri/linkocean/domain/bookmark/service/BookmarkServiceImpl.java
@@ -135,7 +135,7 @@ public class BookmarkServiceImpl implements BookmarkService {
 		final boolean isFavorite = writer.isFavoriteBookmark(bookmark);
 		final boolean isFollow = checkIsFollowQuery.isFollow(profileId, writer);
 
-		final Map<ReactionType, Long> reactionCountMap = reactionQuery.getReactionCountMap(bookmark);
+		final Map<ReactionType, Long> reactionCountMap = bookmarkRepository.countReactionGroup(bookmark.getId());
 		final Map<ReactionType, Boolean> reactionMap = reactionQuery.getReactionMap(profileId, bookmark);
 
 		/* 결과 반환 */

--- a/src/main/java/com/meoguri/linkocean/domain/bookmark/service/BookmarkServiceImpl.java
+++ b/src/main/java/com/meoguri/linkocean/domain/bookmark/service/BookmarkServiceImpl.java
@@ -321,12 +321,11 @@ public class BookmarkServiceImpl implements BookmarkService {
 	@Override
 	public void updateLikeCount(
 		final long bookmarkId,
-		final boolean isAlreadyReacted,
 		final ReactionType existedType,
 		final ReactionType requestType
 	) {
 		if (requestType.equals(LIKE)) {
-			if (isAlreadyReacted && existedType.equals(LIKE)) {
+			if (existedType == LIKE) {
 				/* like 를 두번 요청하여 취소 */
 				bookmarkRepository.subtractLikeCount(bookmarkId);
 			} else {
@@ -334,7 +333,7 @@ public class BookmarkServiceImpl implements BookmarkService {
 				bookmarkRepository.addLikeCount(bookmarkId);
 			}
 		} else if (requestType.equals(HATE)) {
-			if (isAlreadyReacted && existedType.equals(LIKE)) {
+			if (existedType == LIKE) {
 				/* like -> hate 변경 */
 				bookmarkRepository.subtractLikeCount(bookmarkId);
 			}

--- a/src/main/java/com/meoguri/linkocean/domain/bookmark/service/ReactionServiceImpl.java
+++ b/src/main/java/com/meoguri/linkocean/domain/bookmark/service/ReactionServiceImpl.java
@@ -1,15 +1,11 @@
 package com.meoguri.linkocean.domain.bookmark.service;
 
-import java.util.Optional;
-
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.meoguri.linkocean.domain.bookmark.entity.Bookmark;
-import com.meoguri.linkocean.domain.bookmark.entity.Reaction;
 import com.meoguri.linkocean.domain.bookmark.entity.vo.ReactionType;
 import com.meoguri.linkocean.domain.bookmark.persistence.FindBookmarkByIdQuery;
-import com.meoguri.linkocean.domain.bookmark.persistence.ReactionRepository;
 import com.meoguri.linkocean.domain.bookmark.service.dto.ReactionCommand;
 import com.meoguri.linkocean.domain.profile.entity.Profile;
 import com.meoguri.linkocean.domain.profile.persistence.FindProfileByIdQuery;
@@ -23,8 +19,6 @@ public class ReactionServiceImpl implements ReactionService {
 
 	private final BookmarkService bookmarkService;
 
-	private final ReactionRepository reactionRepository;
-
 	private final FindProfileByIdQuery findProfileByIdQuery;
 	private final FindBookmarkByIdQuery findBookmarkByIdQuery;
 
@@ -34,29 +28,15 @@ public class ReactionServiceImpl implements ReactionService {
 		final long profileId = command.getProfileId();
 		final long bookmarkId = command.getBookmarkId();
 
-		final Profile profile = findProfileByIdQuery.findById(profileId);
+		final Profile profile = findProfileByIdQuery.findProfileFetchReactionById(profileId);
 		final Bookmark bookmark = findBookmarkByIdQuery.findById(bookmarkId);
 		final ReactionType requestType = command.getReactionType();
 
-		final Optional<Reaction> oReaction = reactionRepository.findByProfile_idAndBookmark(profileId, bookmark);
-		final boolean isAlreadyReacted = oReaction.isPresent();
-		final ReactionType existedType = isAlreadyReacted ? oReaction.get().getType() : null;
-
-		if (isAlreadyReacted) {
-			if (existedType.equals(requestType)) {
-				/* 북마크에 리액션을 가지고 있으며 같은 타입의 리액션을 하는 경우 취소 */
-				reactionRepository.deleteByProfile_idAndBookmark_id(profileId, bookmarkId);
-			} else {
-				/* 북마크에 리액션을 가지고 있으며 다른 타입의 리액션을 하는 경우 변경*/
-				reactionRepository.updateReaction(profileId, bookmarkId, requestType);
-			}
-		} else {
-			/* 북마크에 리액션을 가지고 있지 않으면 추가 */
-			reactionRepository.save(new Reaction(profile, bookmark, requestType));
-		}
+		/* 리액션 요청 */
+		final ReactionType existedType = profile.requestReaction(bookmark, requestType);
 
 		/* 북마크 좋아요 숫자 업데이트 */
-		bookmarkService.updateLikeCount(bookmarkId, isAlreadyReacted, existedType, requestType);
+		bookmarkService.updateLikeCount(bookmarkId, existedType, requestType);
 	}
 
 }

--- a/src/main/java/com/meoguri/linkocean/domain/profile/entity/FavoriteBookmarkIds.java
+++ b/src/main/java/com/meoguri/linkocean/domain/profile/entity/FavoriteBookmarkIds.java
@@ -19,7 +19,7 @@ import com.meoguri.linkocean.domain.bookmark.entity.Bookmark;
 import lombok.NoArgsConstructor;
 
 @Embeddable
-@NoArgsConstructor(access = PACKAGE)
+@NoArgsConstructor(access = PROTECTED)
 public class FavoriteBookmarkIds {
 
 	@ElementCollection

--- a/src/main/java/com/meoguri/linkocean/domain/profile/entity/Profile.java
+++ b/src/main/java/com/meoguri/linkocean/domain/profile/entity/Profile.java
@@ -43,6 +43,9 @@ public class Profile extends BaseIdEntity {
 	@Embedded
 	private FavoriteBookmarkIds favoriteBookmarkIds = new FavoriteBookmarkIds();
 
+	@Embedded
+	private Reactions reactions = new Reactions();
+
 	@Column(nullable = false, unique = true, length = MAX_PROFILE_USERNAME_LENGTH)
 	private String username;
 

--- a/src/main/java/com/meoguri/linkocean/domain/profile/entity/Profile.java
+++ b/src/main/java/com/meoguri/linkocean/domain/profile/entity/Profile.java
@@ -13,6 +13,7 @@ import javax.persistence.OneToOne;
 
 import com.meoguri.linkocean.domain.BaseIdEntity;
 import com.meoguri.linkocean.domain.bookmark.entity.Bookmark;
+import com.meoguri.linkocean.domain.bookmark.entity.vo.ReactionType;
 import com.meoguri.linkocean.domain.user.entity.User;
 
 import lombok.Getter;
@@ -109,5 +110,10 @@ public class Profile extends BaseIdEntity {
 
 		this.user = user;
 		this.username = username;
+	}
+
+	/* 리액션 요청 */
+	public ReactionType requestReaction(final Bookmark bookmark, final ReactionType requestType) {
+		return reactions.requestReaction(bookmark, requestType);
 	}
 }

--- a/src/main/java/com/meoguri/linkocean/domain/profile/entity/Reaction.java
+++ b/src/main/java/com/meoguri/linkocean/domain/profile/entity/Reaction.java
@@ -14,6 +14,12 @@ import com.meoguri.linkocean.domain.bookmark.entity.vo.ReactionType;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+/**
+ * 북마크에 대한 리액션
+ * - 리액션을 등록할 때 [프로필, 북마크, 리액션 타입]이 존재해야 한다.
+ * - 리액션 타입은 LIKE/HATE 둘 중 하나이다.
+ * - 사용자는 북마크의 리액션을 변경할 수 있다.
+ */
 @Embeddable
 @NoArgsConstructor(access = PROTECTED)
 public class Reaction {

--- a/src/main/java/com/meoguri/linkocean/domain/profile/entity/Reaction.java
+++ b/src/main/java/com/meoguri/linkocean/domain/profile/entity/Reaction.java
@@ -1,19 +1,43 @@
 package com.meoguri.linkocean.domain.profile.entity;
 
+import static com.meoguri.linkocean.exception.Preconditions.*;
 import static javax.persistence.EnumType.*;
+import static lombok.AccessLevel.*;
 
 import javax.persistence.Column;
 import javax.persistence.Embeddable;
 import javax.persistence.Enumerated;
 
+import com.meoguri.linkocean.domain.bookmark.entity.Bookmark;
 import com.meoguri.linkocean.domain.bookmark.entity.vo.ReactionType;
 
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
 @Embeddable
+@NoArgsConstructor(access = PROTECTED)
 public class Reaction {
 
 	@Column(nullable = false, name = "bookmark_id")
 	private long bookmarkId;
 
+	@Getter
 	@Enumerated(STRING)
 	private ReactionType type;
+
+	public Reaction(final Bookmark bookmark, final ReactionType type) {
+		checkNotNull(bookmark);
+		checkNotNull(type);
+
+		this.bookmarkId = bookmark.getId();
+		this.type = type;
+	}
+
+	public boolean isOf(final Bookmark bookmark) {
+		return bookmarkId == bookmark.getId();
+	}
+
+	public void updateType(final ReactionType reactionType) {
+		this.type = reactionType;
+	}
 }

--- a/src/main/java/com/meoguri/linkocean/domain/profile/entity/Reaction.java
+++ b/src/main/java/com/meoguri/linkocean/domain/profile/entity/Reaction.java
@@ -1,0 +1,19 @@
+package com.meoguri.linkocean.domain.profile.entity;
+
+import static javax.persistence.EnumType.*;
+
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
+import javax.persistence.Enumerated;
+
+import com.meoguri.linkocean.domain.bookmark.entity.vo.ReactionType;
+
+@Embeddable
+public class Reaction {
+
+	@Column(nullable = false, name = "bookmark_id")
+	private long bookmarkId;
+
+	@Enumerated(STRING)
+	private ReactionType type;
+}

--- a/src/main/java/com/meoguri/linkocean/domain/profile/entity/Reactions.java
+++ b/src/main/java/com/meoguri/linkocean/domain/profile/entity/Reactions.java
@@ -10,6 +10,7 @@ import javax.persistence.CollectionTable;
 import javax.persistence.ElementCollection;
 import javax.persistence.Embeddable;
 import javax.persistence.JoinColumn;
+import javax.persistence.UniqueConstraint;
 
 import com.meoguri.linkocean.domain.bookmark.entity.Bookmark;
 import com.meoguri.linkocean.domain.bookmark.entity.vo.ReactionType;
@@ -23,7 +24,8 @@ public class Reactions {
 	@ElementCollection
 	@CollectionTable(
 		name = "reaction",
-		joinColumns = @JoinColumn(name = "profile_id")
+		joinColumns = @JoinColumn(name = "profile_id"),
+		uniqueConstraints = @UniqueConstraint(columnNames = {"profile_id", "bookmark_id"})
 	)
 	private Set<Reaction> reactions = new HashSet<>();
 

--- a/src/main/java/com/meoguri/linkocean/domain/profile/entity/Reactions.java
+++ b/src/main/java/com/meoguri/linkocean/domain/profile/entity/Reactions.java
@@ -1,0 +1,25 @@
+package com.meoguri.linkocean.domain.profile.entity;
+
+import static lombok.AccessLevel.*;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import javax.persistence.CollectionTable;
+import javax.persistence.ElementCollection;
+import javax.persistence.Embeddable;
+import javax.persistence.JoinColumn;
+
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@NoArgsConstructor(access = PROTECTED)
+public class Reactions {
+
+	@ElementCollection
+	@CollectionTable(
+		name = "reaction",
+		joinColumns = @JoinColumn(name = "profile_id")
+	)
+	private Set<Reaction> reactions = new HashSet<>();
+}

--- a/src/main/java/com/meoguri/linkocean/domain/profile/entity/Reactions.java
+++ b/src/main/java/com/meoguri/linkocean/domain/profile/entity/Reactions.java
@@ -39,16 +39,14 @@ public class Reactions {
 		final Optional<Reaction> oReaction = reactions.stream().filter(r -> r.isOf(bookmark)).findAny();
 		ReactionType existedReactionType = oReaction.isEmpty() ? null : oReaction.get().getType();
 
-		/* 북마크에 리액션을 가지고 있지 않으면 추가 */
 		if (existedReactionType == null) {
+			/* 북마크에 리액션을 가지고 있지 않으면 추가 */
 			reactions.add(new Reaction(bookmark, requestType));
-		}
-		/* 북마크에 리액션을 가지고 있으며 같은 타입의 리액션을 하는 경우 취소 */
-		else if (existedReactionType.equals(requestType)) {
+		} else if (existedReactionType.equals(requestType)) {
+			/* 북마크에 리액션을 가지고 있으며 같은 타입의 리액션을 하는 경우 취소 */
 			reactions.remove(oReaction.get());
-		}
-		/* 북마크에 리액션을 가지고 있으며 다른 타입의 리액션을 하는 경우 변경*/
-		else {
+		} else {
+			/* 북마크에 리액션을 가지고 있으며 다른 타입의 리액션을 하는 경우 변경*/
 			oReaction.get().updateType(requestType);
 		}
 

--- a/src/main/java/com/meoguri/linkocean/domain/profile/entity/Reactions.java
+++ b/src/main/java/com/meoguri/linkocean/domain/profile/entity/Reactions.java
@@ -3,12 +3,16 @@ package com.meoguri.linkocean.domain.profile.entity;
 import static lombok.AccessLevel.*;
 
 import java.util.HashSet;
+import java.util.Optional;
 import java.util.Set;
 
 import javax.persistence.CollectionTable;
 import javax.persistence.ElementCollection;
 import javax.persistence.Embeddable;
 import javax.persistence.JoinColumn;
+
+import com.meoguri.linkocean.domain.bookmark.entity.Bookmark;
+import com.meoguri.linkocean.domain.bookmark.entity.vo.ReactionType;
 
 import lombok.NoArgsConstructor;
 
@@ -22,4 +26,30 @@ public class Reactions {
 		joinColumns = @JoinColumn(name = "profile_id")
 	)
 	private Set<Reaction> reactions = new HashSet<>();
+
+	/**
+	 * 리액션 요청
+	 * @param bookmark
+	 * @param requestType
+	 * @return 기존에 가지고 있던 리액션 타입 없었다면 null 반환
+	 */
+	public ReactionType requestReaction(final Bookmark bookmark, final ReactionType requestType) {
+		final Optional<Reaction> oReaction = reactions.stream().filter(r -> r.isOf(bookmark)).findAny();
+		ReactionType existedReactionType = oReaction.isEmpty() ? null : oReaction.get().getType();
+
+		/* 북마크에 리액션을 가지고 있지 않으면 추가 */
+		if (existedReactionType == null) {
+			reactions.add(new Reaction(bookmark, requestType));
+		}
+		/* 북마크에 리액션을 가지고 있으며 같은 타입의 리액션을 하는 경우 취소 */
+		else if (existedReactionType.equals(requestType)) {
+			reactions.remove(oReaction.get());
+		}
+		/* 북마크에 리액션을 가지고 있으며 다른 타입의 리액션을 하는 경우 변경*/
+		else {
+			oReaction.get().updateType(requestType);
+		}
+
+		return existedReactionType;
+	}
 }

--- a/src/main/java/com/meoguri/linkocean/domain/profile/persistence/FindProfileByIdQuery.java
+++ b/src/main/java/com/meoguri/linkocean/domain/profile/persistence/FindProfileByIdQuery.java
@@ -23,4 +23,9 @@ public class FindProfileByIdQuery {
 		return profileRepository.findProfileFetchFavoriteIdsById(profileId)
 			.orElseThrow(() -> new LinkoceanRuntimeException(format("no such profile id :%d", profileId)));
 	}
+
+	public Profile findProfileFetchReactionById(long profileId) {
+		return profileRepository.findProfileFetchReactionById(profileId)
+			.orElseThrow(() -> new LinkoceanRuntimeException(format("no such profile id :%d", profileId)));
+	}
 }

--- a/src/main/java/com/meoguri/linkocean/domain/profile/persistence/ProfileRepository.java
+++ b/src/main/java/com/meoguri/linkocean/domain/profile/persistence/ProfileRepository.java
@@ -23,5 +23,11 @@ public interface ProfileRepository extends JpaRepository<Profile, Long>, CustomP
 		+ "left join fetch p.favoriteBookmarkIds "
 		+ "where p.id = :profileId")
 	Optional<Profile> findProfileFetchFavoriteIdsById(long profileId);
+
+	@Query("select p "
+		+ "from Profile p "
+		+ "left join fetch p.reactions "
+		+ "where p.id = :profileId")
+	Optional<Profile> findProfileFetchReactionById(long profileId);
 }
 

--- a/src/main/java/com/meoguri/linkocean/util/Querydsl4RepositorySupport.java
+++ b/src/main/java/com/meoguri/linkocean/util/Querydsl4RepositorySupport.java
@@ -20,11 +20,13 @@ import org.springframework.data.support.PageableExecutionUtils;
 import org.springframework.stereotype.Repository;
 import org.springframework.util.Assert;
 
+import com.meoguri.linkocean.domain.bookmark.entity.vo.ReactionType;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.EntityPath;
 import com.querydsl.core.types.Expression;
 import com.querydsl.core.types.Predicate;
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.EnumPath;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.core.types.dsl.NumberPath;
 import com.querydsl.core.types.dsl.PathBuilder;
@@ -44,6 +46,14 @@ import com.querydsl.sql.SQLTemplates;
  */
 @Repository
 public abstract class Querydsl4RepositorySupport {
+
+	protected static RelationalPathBase<Object> reaction = new RelationalPathBase<>(Object.class, "r", "linkocean",
+		"reaction");
+	protected static NumberPath<Long> r_profileId = Expressions.numberPath(Long.class, reaction, "profile_id");
+
+	protected static NumberPath<Long> r_bookmarkId = Expressions.numberPath(Long.class, reaction, "bookmark_id");
+
+	protected static EnumPath<ReactionType> r_type = Expressions.enumPath(ReactionType.class, reaction, "type");
 
 	protected static RelationalPathBase<Object> favorite = new RelationalPathBase<>(Object.class, "f", "linkocean",
 		"favorite");

--- a/src/test/java/com/meoguri/linkocean/domain/bookmark/persistence/CustomBookmarkRepositoryImplTest.java
+++ b/src/test/java/com/meoguri/linkocean/domain/bookmark/persistence/CustomBookmarkRepositoryImplTest.java
@@ -2,11 +2,13 @@ package com.meoguri.linkocean.domain.bookmark.persistence;
 
 import static com.meoguri.linkocean.domain.bookmark.entity.vo.Category.*;
 import static com.meoguri.linkocean.domain.bookmark.entity.vo.OpenType.*;
+import static com.meoguri.linkocean.domain.bookmark.entity.vo.ReactionType.*;
 import static com.meoguri.linkocean.domain.user.entity.vo.OAuthType.*;
 import static com.meoguri.linkocean.test.support.common.Fixture.*;
 import static org.assertj.core.api.Assertions.*;
 
 import java.util.List;
+import java.util.Map;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -20,6 +22,7 @@ import org.springframework.test.context.TestPropertySource;
 
 import com.meoguri.linkocean.domain.bookmark.entity.Bookmark;
 import com.meoguri.linkocean.domain.bookmark.entity.Tag;
+import com.meoguri.linkocean.domain.bookmark.entity.vo.ReactionType;
 import com.meoguri.linkocean.domain.bookmark.persistence.dto.BookmarkFindCond;
 import com.meoguri.linkocean.domain.linkmetadata.entity.LinkMetadata;
 import com.meoguri.linkocean.domain.profile.entity.Profile;
@@ -516,5 +519,23 @@ class CustomBookmarkRepositoryImplTest extends BasePersistenceTest {
 			assertThat(bookmarkPage.getTotalElements()).isEqualTo(6);
 		}
 
+	}
+
+	@Test
+	void 북마크의_리액션_별_카운트_조회_성공() {
+		//given
+		final Profile profile1 = 사용자_프로필_동시_저장_등록("haha@gmail.com", GOOGLE, "haha", IT);
+		final Profile profile2 = 사용자_프로필_동시_저장_등록("papa@gmail.com", GOOGLE, "papa", IT);
+		final Bookmark bookmark = 북마크_링크_메타데이터_동시_저장(profile1, "www.google.com");
+
+		좋아요_저장(profile2, bookmark);
+		싫어요_저장(profile1, bookmark);
+
+		//when
+		final Map<ReactionType, Long> group = bookmarkRepository.countReactionGroup(bookmark.getId());
+
+		//then
+		assertThat(group.getOrDefault(LIKE, 0L)).isEqualTo(1);
+		assertThat(group.getOrDefault(HATE, 0L)).isEqualTo(1);
 	}
 }

--- a/src/test/java/com/meoguri/linkocean/domain/bookmark/persistence/CustomBookmarkRepositoryImplTest.java
+++ b/src/test/java/com/meoguri/linkocean/domain/bookmark/persistence/CustomBookmarkRepositoryImplTest.java
@@ -528,8 +528,8 @@ class CustomBookmarkRepositoryImplTest extends BasePersistenceTest {
 		final Profile profile2 = 사용자_프로필_동시_저장_등록("papa@gmail.com", GOOGLE, "papa", IT);
 		final Bookmark bookmark = 북마크_링크_메타데이터_동시_저장(profile1, "www.google.com");
 
-		좋아요_저장(profile2, bookmark);
 		싫어요_저장(profile1, bookmark);
+		좋아요_저장(profile2, bookmark);
 
 		//when
 		final Map<ReactionType, Long> group = bookmarkRepository.countReactionGroup(bookmark.getId());

--- a/src/test/java/com/meoguri/linkocean/domain/bookmark/persistence/ReactionQueryTest.java
+++ b/src/test/java/com/meoguri/linkocean/domain/bookmark/persistence/ReactionQueryTest.java
@@ -33,21 +33,6 @@ class ReactionQueryTest extends BasePersistenceTest {
 	}
 
 	@Test
-	void 북마크의_리액션별_카운트_조회_성공() {
-		//given
-		final Profile anotherProfile = 사용자_프로필_동시_저장_등록("papa@gmail.com", GOOGLE, "papa", IT);
-		좋아요_저장(profile, bookmark);
-		싫어요_저장(anotherProfile, bookmark);
-
-		//when
-		final Map<ReactionType, Long> reactionCountMap = reactionQuery.getReactionCountMap(bookmark);
-
-		//then
-		assertThat(reactionCountMap.get(LIKE)).isEqualTo(1);
-		assertThat(reactionCountMap.get(HATE)).isEqualTo(1);
-	}
-
-	@Test
 	void 리액션_여부_맵을_조회할_수_있다() {
 		//given
 		좋아요_저장(profile, bookmark);

--- a/src/test/java/com/meoguri/linkocean/domain/bookmark/persistence/ReactionRepositoryTest.java
+++ b/src/test/java/com/meoguri/linkocean/domain/bookmark/persistence/ReactionRepositoryTest.java
@@ -3,7 +3,6 @@ package com.meoguri.linkocean.domain.bookmark.persistence;
 import static com.meoguri.linkocean.domain.bookmark.entity.vo.Category.*;
 import static com.meoguri.linkocean.domain.bookmark.entity.vo.ReactionType.*;
 import static com.meoguri.linkocean.domain.user.entity.vo.OAuthType.*;
-import static com.meoguri.linkocean.test.support.common.Assertions.*;
 import static org.assertj.core.api.Assertions.*;
 
 import java.util.Map;
@@ -38,28 +37,6 @@ class ReactionRepositoryTest extends BasePersistenceTest {
 		final LinkMetadata linkMetadata = 링크_메타데이터_저장("www.google.com", "구글", "google.png");
 		bookmark = 북마크_저장(profile, linkMetadata, "www.google.com");
 		bookmarkId = bookmark.getId();
-	}
-
-	@Test
-	void deleteByProfile_idAndBookmark_id_성공() {
-		//given
-		final Reaction reaction = reactionRepository.save(new Reaction(profile, bookmark, LIKE));
-
-		//when
-		reactionRepository.deleteByProfile_idAndBookmark_id(profileId, bookmarkId);
-
-		//then
-		assertThat(reactionRepository.findById(reaction.getId())).isEmpty();
-	}
-
-	@Test
-	void 리액션_저장_실패_중복_요청() {
-		//given
-		reactionRepository.save(new Reaction(profile, bookmark, LIKE));
-
-		//when then
-		assertThatDataIntegrityViolationException()
-			.isThrownBy(() -> reactionRepository.save(new Reaction(profile, bookmark, HATE)));
 	}
 
 	@Test

--- a/src/test/java/com/meoguri/linkocean/test/support/persistence/BasePersistenceTest.java
+++ b/src/test/java/com/meoguri/linkocean/test/support/persistence/BasePersistenceTest.java
@@ -15,12 +15,10 @@ import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabas
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 
 import com.meoguri.linkocean.domain.bookmark.entity.Bookmark;
-import com.meoguri.linkocean.domain.bookmark.entity.Reaction;
 import com.meoguri.linkocean.domain.bookmark.entity.Tag;
 import com.meoguri.linkocean.domain.bookmark.entity.vo.Category;
 import com.meoguri.linkocean.domain.bookmark.entity.vo.OpenType;
 import com.meoguri.linkocean.domain.bookmark.persistence.BookmarkRepository;
-import com.meoguri.linkocean.domain.bookmark.persistence.ReactionRepository;
 import com.meoguri.linkocean.domain.bookmark.persistence.TagRepository;
 import com.meoguri.linkocean.domain.linkmetadata.entity.LinkMetadata;
 import com.meoguri.linkocean.domain.linkmetadata.persistence.LinkMetadataRepository;
@@ -59,9 +57,6 @@ public class BasePersistenceTest {
 
 	@Autowired
 	private BookmarkRepository bookmarkRepository;
-
-	@Autowired
-	private ReactionRepository reactionRepository;
 
 	protected boolean isLoaded(final Object entity) {
 		return emf.getPersistenceUnitUtil().isLoaded(entity);
@@ -162,14 +157,14 @@ public class BasePersistenceTest {
 			tags);
 	}
 
-	/* em.flush & em.clear occurs */
+	/* 주의 ! em.flush & em.clear occurs */
 	protected void 좋아요_저장(final Profile profile, final Bookmark bookmark) {
-		reactionRepository.save(new Reaction(profile, bookmark, LIKE));
+		profile.requestReaction(bookmark, LIKE);
 		bookmarkRepository.addLikeCount(bookmark.getId());
 	}
 
 	protected void 싫어요_저장(final Profile profile, final Bookmark bookmark) {
-		reactionRepository.save(new Reaction(profile, bookmark, HATE));
+		profile.requestReaction(bookmark, HATE);
 	}
 
 	protected void 즐겨찾기_저장(final Profile profile, final Bookmark bookmark) {


### PR DESCRIPTION
## 🛠️ 작업 내용
- @Entity 북마크.리액션 deprecation -> @ElementCollection 프로필.리액션

## 🗨️ 기타
- 리액션 요청 (등록) 및 리액션 카운트 맵 퍼올리기 
  까지 ElementCollection 으로 처리하도록 변경 하였습니다.

- 이후 리액션 여부 확인 만 이주시키면 Reaction, ReactionRepository, ReactionQuery 시리즈 다 없앨 수 있을것 같습니다.
  이 과정에서 상세조회의 경우 영속성에서 dto 를 퍼올리도록 변경 될 수도 있을것 같습니다.
  메서드 시그니처를 어떻게 가져가야 할지 고민이네요

## 😎 리뷰어
@ndy2 , @jk05018 , @NewEgoDoc, @hyuk0309