### PR TITLE
[LO-183] Local Test DB 이름 변경

### DIFF
--- a/env/mysql.env
+++ b/env/mysql.env
@@ -1,2 +1,2 @@
-MYSQL_DATABASE=linkoceantest
+MYSQL_DATABASE=linkocean
 MYSQL_ROOT_PASSWORD=root1234

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -3,7 +3,7 @@ spring:
     include: oauth, aws
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
-    url: jdbc:mysql://localhost:3306/linkoceantest
+    url: jdbc:mysql://localhost:3306/linkocean
     username: root
     password: root1234
 


### PR DESCRIPTION
## 🛠️ 작업 내용
- Local Test DB 이름 변경

## 🗨️ 기타
<!-- PR 포인트 혹은 궁금한 점 등등 적어주시면 됩니다. 없으시면 지워주세요 -->
- 테스트 DB를 MySQL로 바꾸면서 기존 도커 DB 이름이 Linkoceantest로 바꿨습니다. 그런데 생각해보니까 local에서는 하나의 디비로 test도 하고 local에서 돌려보는 용도로 사용하는게 좋을 것 같아 이름을 Linkocean으로 바꿨습니다! (flyway 설정 파일에도 아직 linkocean으로 남아 있더라고요. 그래서 둘로 나눌까 고민했는데 나누는건 과한 것 같아 이렇게 바꿨습니다. 테스트할때는 데이터를 세팅하고 밀어주는 작업이 기본으로 들어가기 때문에 Local에서 같은 DB로 테스트하는것도 문제 없을 것 같아요.~)

## 😎 리뷰어
@ndy2 , @jk05018 , @NewEgoDoc, @hyuk0309