### PR TITLE
[LO-198] api 문서 jar에 말기

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,53 +32,6 @@ jacoco {
     toolVersion = '0.8.7'
 }
 
-jacocoTestReport {
-    reports {
-        html.enabled(true)
-        xml.enabled(false)
-        csv.enabled(false)
-    }
-
-    finalizedBy 'jacocoTestCoverageVerification'
-
-    dependsOn test
-
-    def Qdomains = []
-    for (qPattern in "QA".."QZ") {  // qPattern = "*.QA","*.QB","*.QC", ... "*.QZ"
-        Qdomains.add("com/meoguri/**/" + qPattern + "*.*")
-    }
-
-    afterEvaluate {
-        classDirectories.setFrom(files(classDirectories.files.collect {
-            fileTree(dir: it, exclude: [
-                    "com/meoguri/**/dto/*.*",
-                    "com/meoguri/**/util/*.*",
-                    "com/meoguri/**/exception/*.*",
-                    "com/meoguri/**/*Properties.*",
-            ] + Qdomains)
-        }))
-    }
-}
-
-jacocoTestCoverageVerification {
-    violationRules {
-        rule {
-            enabled = false
-            element = 'BUNDLE'
-
-            limit {
-                counter = 'LINE'
-                value = 'COVEREDRATIO'
-                minimum = 0.80
-            }
-
-            excludes = []
-        }
-    }
-
-    finalizedBy 'asciidoctor'
-}
-
 repositories {
     mavenCentral()
 }
@@ -132,11 +85,67 @@ dependencies {
     testImplementation 'io.findify:s3mock_2.12:0.2.6'
 }
 
+task copyProperty(type: Copy) {
+    from file('./config')
+    into file('./src/main/resources')
+}
+
+processResources {
+    dependsOn copyProperty
+}
+
 tasks.named('test') {
     outputs.dir snippetsDir
     useJUnitPlatform()
 
     finalizedBy 'jacocoTestReport'
+}
+
+jacocoTestReport {
+    reports {
+        html.enabled(true)
+        xml.enabled(false)
+        csv.enabled(false)
+    }
+
+    finalizedBy 'jacocoTestCoverageVerification'
+
+    dependsOn test
+
+    def Qdomains = []
+    for (qPattern in "QA".."QZ") {  // qPattern = "*.QA","*.QB","*.QC", ... "*.QZ"
+        Qdomains.add("com/meoguri/**/" + qPattern + "*.*")
+    }
+
+    afterEvaluate {
+        classDirectories.setFrom(files(classDirectories.files.collect {
+            fileTree(dir: it, exclude: [
+                    "com/meoguri/**/dto/*.*",
+                    "com/meoguri/**/util/*.*",
+                    "com/meoguri/**/exception/*.*",
+                    "com/meoguri/**/*Properties.*",
+            ] + Qdomains)
+        }))
+    }
+}
+
+jacocoTestCoverageVerification {
+    violationRules {
+        rule {
+            enabled = false
+            element = 'BUNDLE'
+
+            limit {
+                counter = 'LINE'
+                value = 'COVEREDRATIO'
+                minimum = 0.80
+            }
+
+            excludes = []
+        }
+    }
+
+    finalizedBy 'asciidoctor'
 }
 
 asciidoctor {
@@ -156,20 +165,18 @@ asciidoctor.doFirst {
     delete file('src/main/resources/static/docs')
 }
 
+bootJar {
+    dependsOn asciidoctor
+    from ('${asciidoctor.outputDir}') {
+        into 'static/docs'
+    }
+}
+
 task copyDocument(type: Copy) {
     dependsOn asciidoctor
 
     from file('build/docs/asciidoc/')
     into file('src/main/resources/static/docs')
-}
-
-task copyProperty(type: Copy) {
-    from file('./config')
-    into file('./src/main/resources')
-}
-
-processResources {
-    dependsOn copyProperty
 }
 
 build {


### PR DESCRIPTION
## 🛠️ 작업 내용
- api 문서 jar에 말기

## 🗨️ 기타
<!-- PR 포인트 혹은 궁금한 점 등등 적어주시면 됩니다. 없으시면 지워주세요 -->
- ascidoctor로 만든 api 문서가 jar 파일에 포함되지 않는 이슈가 있어 해결했어요.
<img width="326" alt="스크린샷 2022-08-28 오후 6 50 02" src="https://user-images.githubusercontent.com/29492667/187068020-e2f81c93-7381-4720-ae89-0e6eed126ad7.png">

- 추가로 gradle.build 파일이 build 순서를 잘 표현하게 리펙토링 했어요.

- @ndy2 하하 로컬 JDK 스펙 여기에 남겨주세요!! 😄 

## 😎 리뷰어
@ndy2 , @jk05018 , @NewEgoDoc, @hyuk0309