### PR TITLE
[LO-202] jsoup 이슈 해결

### DIFF
--- a/src/main/java/com/meoguri/linkocean/domain/linkmetadata/entity/vo/Link.java
+++ b/src/main/java/com/meoguri/linkocean/domain/linkmetadata/entity/vo/Link.java
@@ -22,8 +22,8 @@ import lombok.NoArgsConstructor;
 @Embeddable
 public final class Link {
 
-	private static final String URL_REGEX =
-		"^((http|https)://)?(www.)?([^:\\/\\s]+)(:([^\\/]*))?((\\/[^\\s/\\/]+)*)?\\/?([^#\\s\\?]*)(\\?([^#\\s]*))?(#(\\w*))?([가-힣])?$";
+	private static final String URL_REGEX = "^((http|https)://)?(www.)?([^:\\/\\s]+)(:([^\\/]*))?"
+		+ "((\\/[^\\s/\\/]+)*)?\\/?([^#\\s\\?]*)(\\?([^#\\s]*))?(#(\\w*))?([가-힣])?$";
 	private static final Pattern URL_PATTERN = Pattern.compile(URL_REGEX);
 
 	@Column(nullable = false, unique = true, length = 700)

--- a/src/main/java/com/meoguri/linkocean/domain/linkmetadata/entity/vo/Link.java
+++ b/src/main/java/com/meoguri/linkocean/domain/linkmetadata/entity/vo/Link.java
@@ -22,7 +22,8 @@ import lombok.NoArgsConstructor;
 @Embeddable
 public final class Link {
 
-	private static final String URL_REGEX = "^((http|https)://)?(www.)?([a-zA-Z0-9]+)\\.[a-z]+([a-zA-z0-9.?#]+)?";
+	private static final String URL_REGEX =
+		"^((http|https)://)?(www.)?([^:\\/\\s]+)(:([^\\/]*))?((\\/[^\\s/\\/]+)*)?\\/?([^#\\s\\?]*)(\\?([^#\\s]*))?(#(\\w*))?([가-힣])?$";
 	private static final Pattern URL_PATTERN = Pattern.compile(URL_REGEX);
 
 	@Column(nullable = false, unique = true, length = 700)

--- a/src/test/java/com/meoguri/linkocean/domain/linkmetadata/entity/vo/LinkTest.java
+++ b/src/test/java/com/meoguri/linkocean/domain/linkmetadata/entity/vo/LinkTest.java
@@ -17,7 +17,10 @@ class LinkTest extends BaseEntityTest {
 			"https://www.naver.com",
 			"www.naver.com",
 			"naver.com",
-			"dev.naver.com"
+			"dev.naver.com",
+			"https://yozm.wishket.com/magazine/detail/1217",
+			"https://map.naver.com/v5/entry/place/1368783268?c=14142328.7122523,4515635.3114847,13,0,0,0,dh&placePath=%2Fhome&entry=plt",
+			"https://search.naver.com/search.naver?where=nexearch&sm=top_hty&fbm=0&ie=utf8&query=쵸리상경"
 		}
 	)
 	void url_생성_성공(final String textUrl) {


### PR DESCRIPTION
<!-- PR 제목 양식 예시: [LO-N] 회원 기능 도메인 -->

## 🛠️ 작업 내용
- jsoup 이슈 해결

## 🗨️ 기타
<!-- PR 포인트 혹은 궁금한 점 등등 적어주시면 됩니다. 없으시면 지워주세요 -->
- 링크 메타데이터 제목 조회 API에서 예상과 다르게 400 상태 코드를 반환하는 이슈가 있어서 해결했습니다. 원인은 url 정규식이 좁은 범위의 url 포맷만 허용해줘서 그랬습니다.  

<hr/>

링크 메타데이터 관련 이슈를 해결하면서 수정하면 더 좋아질 부분들이 보여 제가 추가로 작업하겠습니다. 

1. 북마크 엔티티에서 링크 메타데이터 엔티티를 참조하고 있습니다. 그런데 북마크와 링크 메타데이터는 다른 에그리거트이므로 좋지 않은 설계같습니다. 
따라서 북마크 엔티티에서 링크 메타데이터 ID만 참조하도록 변경할 예정입니다.

2. 정책적으로 북마크는 무조건 링크 메타데이터 아이디를 외래키로 가져야 합니다. 그런데 생각해보니까 북마크 url에 제대로된 링크 메타데이터가 존재하지 않다면, 의미가 없는 참조같다는 생각이 들었습니다. 이로 인해 링크 메타데이터 테이블에도 필요없는 데이터가 쌓이는 것 같아요. 
따라서 북마크에서 링크 메타데이터 아이디를 갖지만 null도 허용하게 바꿀 생각입니다. 추가로 링크 메타데이터 타이틀 조회시에도 링크 메타데이터가 존재하지 않으면 db에 저장하지 않을 생각입니다. 

## 😎 리뷰어
@ndy2 , @jk05018 , @NewEgoDoc, @hyuk0309
