### PR TITLE
[LO-203] 북마크 링크메타데이터 ID 참조

### DIFF
--- a/src/main/java/com/meoguri/linkocean/domain/bookmark/entity/Bookmark.java
+++ b/src/main/java/com/meoguri/linkocean/domain/bookmark/entity/Bookmark.java
@@ -24,7 +24,6 @@ import com.meoguri.linkocean.domain.bookmark.entity.vo.BookmarkStatus;
 import com.meoguri.linkocean.domain.bookmark.entity.vo.Category;
 import com.meoguri.linkocean.domain.bookmark.entity.vo.OpenType;
 import com.meoguri.linkocean.domain.bookmark.entity.vo.TagIds;
-import com.meoguri.linkocean.domain.linkmetadata.entity.LinkMetadata;
 import com.meoguri.linkocean.domain.profile.command.entity.Profile;
 
 import lombok.Getter;
@@ -49,8 +48,9 @@ public class Bookmark extends BaseIdEntity {
 	@JoinColumn(name = "profile_id")
 	private Profile writer;
 
-	@ManyToOne(fetch = LAZY, optional = false)
-	private LinkMetadata linkMetadata;
+	/* 링크 메타 데이터 식별자 */
+	@Column(name = "linkMetadata_id")
+	private Long linkMetadataId;
 
 	@Embedded
 	private TagIds tagIds;
@@ -87,7 +87,7 @@ public class Bookmark extends BaseIdEntity {
 	private LocalDateTime updatedAt;
 
 	/* 북마크 등록시 사용하는 생성자 */
-	public Bookmark(final Profile writer, final LinkMetadata linkMetadata, final String title, final String memo,
+	public Bookmark(final Profile writer, final Long linkMetadataId, final String title, final String memo,
 		final OpenType openType, final Category category, final String url, final TagIds tagIds) {
 		checkNotNull(openType);
 		checkNotNull(tagIds);
@@ -95,7 +95,7 @@ public class Bookmark extends BaseIdEntity {
 		checkNullableStringLength(title, MAX_BOOKMARK_TITLE_LENGTH, "제목의 길이는 %d보다 작아야 합니다.", MAX_BOOKMARK_TITLE_LENGTH);
 
 		this.writer = writer;
-		this.linkMetadata = linkMetadata;
+		this.linkMetadataId = linkMetadataId;
 		this.title = title;
 		this.memo = memo;
 		this.openType = openType;

--- a/src/main/java/com/meoguri/linkocean/domain/bookmark/persistence/BookmarkRepository.java
+++ b/src/main/java/com/meoguri/linkocean/domain/bookmark/persistence/BookmarkRepository.java
@@ -34,7 +34,6 @@ public interface BookmarkRepository extends JpaRepository<Bookmark, Long>, Custo
 	@Query("select distinct b "
 		+ "from Bookmark b "
 		+ "join fetch b.writer "
-		+ "join fetch b.linkMetadata "
 		+ "left join fetch b.tagIds t "
 		+ "where b.id = :id "
 		+ "and b.status = com.meoguri.linkocean.domain.bookmark.entity.vo.BookmarkStatus.REGISTERED")

--- a/src/main/java/com/meoguri/linkocean/domain/bookmark/persistence/CustomBookmarkRepository.java
+++ b/src/main/java/com/meoguri/linkocean/domain/bookmark/persistence/CustomBookmarkRepository.java
@@ -9,13 +9,12 @@ import org.springframework.data.domain.Pageable;
 import com.meoguri.linkocean.domain.bookmark.entity.Bookmark;
 import com.meoguri.linkocean.domain.bookmark.persistence.dto.BookmarkFindCond;
 import com.meoguri.linkocean.domain.bookmark.persistence.dto.FindUsedTagIdWithCountResult;
-import com.meoguri.linkocean.domain.linkmetadata.entity.LinkMetadata;
 import com.meoguri.linkocean.domain.profile.command.entity.Profile;
 import com.meoguri.linkocean.domain.profile.command.entity.vo.ReactionType;
 
 public interface CustomBookmarkRepository {
 
-	boolean existsByWriterAndLinkMetadata(Profile writer, LinkMetadata linkMetadata);
+	boolean existsByWriterAndLinkMetadata(Profile writer, Long linkMetadata);
 
 	/* 피드 북마크 조회 */
 	Page<Bookmark> findBookmarks(BookmarkFindCond findCond, Pageable pageable);

--- a/src/main/java/com/meoguri/linkocean/domain/bookmark/persistence/CustomBookmarkRepositoryImpl.java
+++ b/src/main/java/com/meoguri/linkocean/domain/bookmark/persistence/CustomBookmarkRepositoryImpl.java
@@ -27,7 +27,6 @@ import com.meoguri.linkocean.domain.bookmark.entity.vo.OpenType;
 import com.meoguri.linkocean.domain.bookmark.persistence.dto.BookmarkFindCond;
 import com.meoguri.linkocean.domain.bookmark.persistence.dto.FindUsedTagIdWithCountResult;
 import com.meoguri.linkocean.domain.bookmark.persistence.dto.QFindUsedTagIdWithCountResult;
-import com.meoguri.linkocean.domain.linkmetadata.entity.LinkMetadata;
 import com.meoguri.linkocean.domain.profile.command.entity.Profile;
 import com.meoguri.linkocean.domain.profile.command.entity.vo.ReactionType;
 import com.meoguri.linkocean.util.querydsl.CustomPath;
@@ -44,12 +43,12 @@ public class CustomBookmarkRepositoryImpl extends Querydsl4RepositorySupport imp
 	}
 
 	@Override
-	public boolean existsByWriterAndLinkMetadata(final Profile writer, final LinkMetadata linkMetadata) {
+	public boolean existsByWriterAndLinkMetadata(final Profile writer, final Long linkMetadataId) {
 		return selectOne()
 			.from(bookmark)
 			.where(
 				writerIdEq(writer.getId()),
-				linMetadataEq(linkMetadata),
+				linMetadataIdEq(linkMetadataId),
 				registered()
 			).fetchFirst() != null;
 	}
@@ -80,8 +79,7 @@ public class CustomBookmarkRepositoryImpl extends Querydsl4RepositorySupport imp
 			selectFrom(bookmark),
 			joinIfs(
 				joinIf(category != null,
-					() -> join(bookmark.writer).fetchJoin()
-						.join(bookmark.linkMetadata).fetchJoin()),
+					() -> join(bookmark.writer).fetchJoin()),
 				joinIf(tags != null,
 					() -> join(bookmark.writer).fetchJoin())
 			),
@@ -131,8 +129,8 @@ public class CustomBookmarkRepositoryImpl extends Querydsl4RepositorySupport imp
 		return nullSafeBuilder(() -> bookmark.title.containsIgnoreCase(title));
 	}
 
-	private BooleanBuilder linMetadataEq(final LinkMetadata linkMetadata) {
-		return nullSafeBuilder(() -> bookmark.linkMetadata.eq(linkMetadata));
+	private BooleanBuilder linMetadataIdEq(final Long linkMetadataId) {
+		return nullSafeBuilder(() -> bookmark.linkMetadataId.eq(linkMetadataId));
 	}
 
 	private BooleanBuilder categoryEq(final Category category) {

--- a/src/main/java/com/meoguri/linkocean/domain/linkmetadata/persistence/FindLinkMetadataByIdQuery.java
+++ b/src/main/java/com/meoguri/linkocean/domain/linkmetadata/persistence/FindLinkMetadataByIdQuery.java
@@ -1,0 +1,28 @@
+package com.meoguri.linkocean.domain.linkmetadata.persistence;
+
+import static java.lang.String.*;
+
+import java.util.List;
+import java.util.Set;
+
+import com.meoguri.linkocean.annotation.Query;
+import com.meoguri.linkocean.domain.linkmetadata.entity.LinkMetadata;
+import com.meoguri.linkocean.exception.LinkoceanRuntimeException;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Query
+public class FindLinkMetadataByIdQuery {
+
+	private final LinkMetadataRepository linkMetadataRepository;
+
+	public LinkMetadata findById(final Long id) {
+		return linkMetadataRepository.findById(id)
+			.orElseThrow(() -> new LinkoceanRuntimeException(format("no such linkmetadata with id : %d", id)));
+	}
+
+	public Set<LinkMetadata> findByIds(final List<Long> ids) {
+		return linkMetadataRepository.findByIds(ids);
+	}
+}

--- a/src/main/java/com/meoguri/linkocean/domain/linkmetadata/persistence/LinkMetadataRepository.java
+++ b/src/main/java/com/meoguri/linkocean/domain/linkmetadata/persistence/LinkMetadataRepository.java
@@ -1,6 +1,8 @@
 package com.meoguri.linkocean.domain.linkmetadata.persistence;
 
+import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -21,4 +23,9 @@ public interface LinkMetadataRepository extends JpaRepository<LinkMetadata, Long
 
 	/* 배치작업 최적화를 위해 Slice 이용 */
 	Slice<LinkMetadata> findBy(Pageable pageable);
+
+	@Query("select l "
+		+ "from LinkMetadata l "
+		+ "where l.id in :ids")
+	Set<LinkMetadata> findByIds(List<Long> ids);
 }

--- a/src/test/java/com/meoguri/linkocean/domain/bookmark/entity/BookmarkTest.java
+++ b/src/test/java/com/meoguri/linkocean/domain/bookmark/entity/BookmarkTest.java
@@ -69,7 +69,7 @@ class BookmarkTest extends BaseEntityTest {
 	@Test
 	void 북마크_업데이트_성공() {
 		//given
-		final Bookmark bookmark = createBookmark();
+		final Bookmark bookmark = createBookmarkWithLinkMetaData();
 		final String updatedTitle = "updatedTitle";
 		final String updatedMemo = "updatedMemo";
 		final Category category = HUMANITIES;
@@ -105,7 +105,8 @@ class BookmarkTest extends BaseEntityTest {
 
 		//when then
 		assertThatIllegalArgumentException().isThrownBy(
-			() -> createBookmark().update(tooLongTitle, "updatedMemo", HUMANITIES, PRIVATE, createTagIds()));
+			() -> createBookmarkWithLinkMetaData().update(tooLongTitle, "updatedMemo", HUMANITIES, PRIVATE,
+				createTagIds()));
 	}
 
 }

--- a/src/test/java/com/meoguri/linkocean/domain/bookmark/entity/BookmarkTest.java
+++ b/src/test/java/com/meoguri/linkocean/domain/bookmark/entity/BookmarkTest.java
@@ -16,7 +16,6 @@ import org.springframework.test.util.ReflectionTestUtils;
 import com.meoguri.linkocean.domain.bookmark.entity.vo.Category;
 import com.meoguri.linkocean.domain.bookmark.entity.vo.OpenType;
 import com.meoguri.linkocean.domain.bookmark.entity.vo.TagIds;
-import com.meoguri.linkocean.domain.linkmetadata.entity.LinkMetadata;
 import com.meoguri.linkocean.domain.profile.command.entity.Profile;
 import com.meoguri.linkocean.domain.tag.entity.Tag;
 import com.meoguri.linkocean.test.support.domain.entity.BaseEntityTest;
@@ -31,25 +30,25 @@ class BookmarkTest extends BaseEntityTest {
 	void 북마크_생성_성공(final String memo, final String title) {
 		//given
 		final Profile profile = createProfile();
-		final LinkMetadata linkMetadata = createLinkMetadata();
+		final Long linkMetadataId = createLinkMetadata().getId();
 		final OpenType openType = ALL;
 		final Category category = IT;
 		final String url = "www.naver.com";
 
 		//when
 		final Bookmark bookmark =
-			new Bookmark(profile, linkMetadata, title, memo, openType, category, url, createTagIds());
+			new Bookmark(profile, linkMetadataId, title, memo, openType, category, url, createTagIds());
 
 		//then
 		assertThat(bookmark).isNotNull()
 			.extracting(
 				Bookmark::getWriter,
 				Bookmark::getTitle,
-				Bookmark::getLinkMetadata,
+				Bookmark::getLinkMetadataId,
 				Bookmark::getMemo,
 				Bookmark::getCategory,
 				Bookmark::getOpenType
-			).containsExactly(profile, title, linkMetadata, memo, category, openType);
+			).containsExactly(profile, title, linkMetadataId, memo, category, openType);
 
 		assertThat(bookmark)
 			.extracting(Bookmark::getCreatedAt, Bookmark::getUpdatedAt)
@@ -63,7 +62,7 @@ class BookmarkTest extends BaseEntityTest {
 
 		//when then
 		assertThatIllegalArgumentException()
-			.isThrownBy(() -> new Bookmark(createProfile(), createLinkMetadata(),
+			.isThrownBy(() -> new Bookmark(createProfile(), createLinkMetadata().getId(),
 				tooLongTitle, "memo", ALL, IT, "www.google.com", createTagIds()));
 	}
 

--- a/src/test/java/com/meoguri/linkocean/domain/bookmark/persistence/BookmarkRepositoryTest.java
+++ b/src/test/java/com/meoguri/linkocean/domain/bookmark/persistence/BookmarkRepositoryTest.java
@@ -77,7 +77,6 @@ class BookmarkRepositoryTest extends BasePersistenceTest {
 		assertAll(
 			() -> assertThat(oFindBookmark).isPresent(),
 			() -> assertThat(isLoaded(oFindBookmark.get().getWriter())).isEqualTo(true),
-			() -> assertThat(isLoaded(oFindBookmark.get().getLinkMetadata())).isEqualTo(true),
 			() -> assertThat(oFindBookmark.get().getTagIds()).containsExactly(tagId1)
 		);
 	}

--- a/src/test/java/com/meoguri/linkocean/domain/bookmark/persistence/CustomBookmarkRepositoryImplTest.java
+++ b/src/test/java/com/meoguri/linkocean/domain/bookmark/persistence/CustomBookmarkRepositoryImplTest.java
@@ -78,7 +78,7 @@ class CustomBookmarkRepositoryImplTest extends BasePersistenceTest {
 
 		//when
 		final boolean exists =
-			bookmarkRepository.existsByWriterAndLinkMetadata(profile, linkMetadata);
+			bookmarkRepository.existsByWriterAndLinkMetadata(profile, linkMetadata.getId());
 
 		//then
 		assertThat(exists).isEqualTo(true);

--- a/src/test/java/com/meoguri/linkocean/domain/bookmark/service/BookmarkServiceImplTest.java
+++ b/src/test/java/com/meoguri/linkocean/domain/bookmark/service/BookmarkServiceImplTest.java
@@ -83,7 +83,7 @@ class BookmarkServiceImplTest extends BaseServiceTest {
 		}
 
 		@Test
-		void 중복_url_북마크_생성_요청에_따라_실패() {
+		void 북마크_등록_실패_중복_url() {
 			//given
 			북마크_등록(profileId, "www.youtube.com");
 

--- a/src/test/java/com/meoguri/linkocean/domain/linkmetadata/persistence/LinkMetadataRepositoryTest.java
+++ b/src/test/java/com/meoguri/linkocean/domain/linkmetadata/persistence/LinkMetadataRepositoryTest.java
@@ -3,7 +3,9 @@ package com.meoguri.linkocean.domain.linkmetadata.persistence;
 import static com.meoguri.linkocean.test.support.common.Assertions.*;
 import static org.assertj.core.api.Assertions.*;
 
+import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -59,5 +61,21 @@ class LinkMetadataRepositoryTest extends BasePersistenceTest {
 
 		assertThatDataIntegrityViolationException()
 			.isThrownBy(() -> linkMetadataRepository.save(new LinkMetadata(duplicatedLink, "네이버", "naver.png")));
+	}
+
+	@Test
+	void 링크_메타데이터_집합_조회() {
+		//given
+		final Long id1 = 링크_메타데이터_저장("https://www.naver.com", "네이버", "naver.png").getId();
+		final Long id2 = 링크_메타데이터_저장("https://www.google.com", "구글", "google.png").getId();
+		final Long id3 = 링크_메타데이터_저장("https://www.kakao.com", "카카오", "kakao.png").getId();
+
+		//when
+		final Set<LinkMetadata> linkMetaDatas = linkMetadataRepository.findByIds(List.of(id1, id2, id3));
+
+		//then
+		assertThat(linkMetaDatas)
+			.extracting(LinkMetadata::getId)
+			.containsExactlyInAnyOrder(id1, id2, id3);
 	}
 }

--- a/src/test/java/com/meoguri/linkocean/domain/profile/command/entity/ProfileTest.java
+++ b/src/test/java/com/meoguri/linkocean/domain/profile/command/entity/ProfileTest.java
@@ -145,8 +145,10 @@ class ProfileTest extends BaseEntityTest {
 			final LinkMetadata naver = new LinkMetadata("www.naver.com", "네이버", "naver.png");
 			final LinkMetadata google = new LinkMetadata("www.google.com", "구글", "google.png");
 
-			bookmark1 = new Bookmark(profile, naver, "bookmark1", null, ALL, null, "www.naver.com", createTagIds());
-			bookmark2 = new Bookmark(profile, google, "bookmark2", null, ALL, null, "www.google.com", createTagIds());
+			bookmark1 = new Bookmark(profile, naver.getId(), "bookmark1", null, ALL, null, "www.naver.com",
+				createTagIds());
+			bookmark2 = new Bookmark(profile, google.getId(), "bookmark2", null, ALL, null, "www.google.com",
+				createTagIds());
 
 			ReflectionTestUtils.setField(bookmark1, "id", 1L);
 			ReflectionTestUtils.setField(bookmark2, "id", 2L);

--- a/src/test/java/com/meoguri/linkocean/test/support/domain/entity/BaseEntityTest.java
+++ b/src/test/java/com/meoguri/linkocean/test/support/domain/entity/BaseEntityTest.java
@@ -25,7 +25,7 @@ public abstract class BaseEntityTest {
 	}
 
 	protected static Bookmark createBookmark() {
-		return new Bookmark(createProfile(), createLinkMetadata(), "title", "dream company", OpenType.ALL, null,
+		return new Bookmark(createProfile(), createLinkMetadata().getId(), "title", "dream company", OpenType.ALL, null,
 			"google.com", createTagIds());
 	}
 

--- a/src/test/java/com/meoguri/linkocean/test/support/domain/entity/BaseEntityTest.java
+++ b/src/test/java/com/meoguri/linkocean/test/support/domain/entity/BaseEntityTest.java
@@ -24,7 +24,7 @@ public abstract class BaseEntityTest {
 		return new TagIds(Arrays.stream(tags).boxed().collect(toList()));
 	}
 
-	protected static Bookmark createBookmark() {
+	protected static Bookmark createBookmarkWithLinkMetaData() {
 		return new Bookmark(createProfile(), createLinkMetadata().getId(), "title", "dream company", OpenType.ALL, null,
 			"google.com", createTagIds());
 	}

--- a/src/test/java/com/meoguri/linkocean/test/support/domain/persistence/BasePersistenceTest.java
+++ b/src/test/java/com/meoguri/linkocean/test/support/domain/persistence/BasePersistenceTest.java
@@ -116,7 +116,7 @@ public abstract class BasePersistenceTest {
 		final long... tagIds
 	) {
 		return bookmarkRepository.save(new Bookmark(writer,
-			linkMetadata,
+			linkMetadata.getId(),
 			title,
 			memo,
 			openType,


### PR DESCRIPTION
<!-- PR 제목 양식 예시: [LO-N] 회원 기능 도메인 -->

## 🛠️ 작업 내용
- 북마크 링크메타데이터 ID 참조

## 🗨️ 기타
<!-- PR 포인트 혹은 궁금한 점 등등 적어주시면 됩니다. 없으시면 지워주세요 -->
- 에그리거트끼리 엔티티로 의존관계를 맺으면 JPA의 편리한 기능을 사용할 수 있지만, 에그리거트끼리 결합도가 높아져 여러 단점이 존재합니다. 대안으로 에그리거트 사이의 의존관계를 식별자를 통해 맺을 수 있습니다. 그러면 결합도가 낮아져 여러 단점들이 해소됩니다. 
- 위의 이유로 북마크에서 링크 메타데이터의 아이디를 식별하도록 바꿨습니다. 
- 진행하면서 큰 사이드 이팩트는 북마크 조회 로직에서 기존에는 폐치 조인을 이용해 링크 메타데이터를 땡겨왔는데 그렇게 하지 못하기때문에 서비스 에서 링크 메타데이터 집합을 가져와 말아주는 방식으로 변경했습니다. 

- DDD책 아주 나이스네요! ㅎㅎ 😄 

## 😎 리뷰어
@ndy2 , @jk05018 , @NewEgoDoc, @hyuk0309