### PR TITLE
[LO-206] 북마크 생성 정책 변경

### DIFF
--- a/src/main/java/com/meoguri/linkocean/domain/bookmark/entity/Bookmark.java
+++ b/src/main/java/com/meoguri/linkocean/domain/bookmark/entity/Bookmark.java
@@ -34,8 +34,9 @@ import lombok.NoArgsConstructor;
 
 /**
  *  북마크 (인터넷 즐겨찾기)
- *  - 북마크를 등록할 때 [프로필, 링크 메타데이터, 제목, 공개 범위]가 필수로 존재해야 하며 추가로 [메모, 카테고리, url, 태그 목록]를 입력 수 있다.
+ *  - 북마크를 등록할 때 [프로필, 제목, 공개 범위, url]가 필수로 존재해야 하며 추가로 [메모, 카테고리, url, 태그 목록]를 입력 수 있다.
  *  - 사용자는 [url]당 하나의 북마크를 가질 수 있다.
+ *  - 북마크 url에 링크 메타데이터 값이 없어도 된다.
  *  - 북마크의 [이름. 메모, 카테고리, 공개 범위, 태그 목록]를 수정할 수 있다.
  *  - 북마크를 삭제할 수 있다.
  *  - 북마크의 좋아요 수를 변경할 수 있다.
@@ -52,7 +53,7 @@ public class Bookmark extends BaseIdEntity {
 	private Profile writer;
 
 	/* 링크 메타 데이터 식별자 */
-	@Column(name = "linkMetadata_id")
+	@Column(name = "link_metadata_id")
 	private Long linkMetadataId;
 
 	@Embedded
@@ -95,6 +96,7 @@ public class Bookmark extends BaseIdEntity {
 	/* 북마크 등록시 사용하는 생성자 */
 	public Bookmark(final Profile writer, final Long linkMetadataId, final String title, final String memo,
 		final OpenType openType, final Category category, final String url, final TagIds tagIds) {
+		checkNotNull(writer);
 		checkNotNull(openType);
 		checkNotNull(tagIds);
 		checkNotNull(url);

--- a/src/main/java/com/meoguri/linkocean/domain/bookmark/entity/Bookmark.java
+++ b/src/main/java/com/meoguri/linkocean/domain/bookmark/entity/Bookmark.java
@@ -8,6 +8,7 @@ import static lombok.AccessLevel.*;
 
 import java.time.LocalDateTime;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 import javax.persistence.Column;
@@ -153,6 +154,10 @@ public class Bookmark extends BaseIdEntity {
 	/* 리액션 확인 */
 	public Map<ReactionType, Boolean> checkReaction(final long profileId) {
 		return reactions.checkReaction(profileId);
+	}
+
+	public Optional<Long> getLinkMetadataId() {
+		return Optional.ofNullable(linkMetadataId);
 	}
 
 	public Set<Long> getTagIds() {

--- a/src/main/java/com/meoguri/linkocean/domain/bookmark/persistence/CustomBookmarkRepository.java
+++ b/src/main/java/com/meoguri/linkocean/domain/bookmark/persistence/CustomBookmarkRepository.java
@@ -12,7 +12,7 @@ import com.meoguri.linkocean.domain.profile.entity.Profile;
 
 public interface CustomBookmarkRepository {
 
-	boolean existsByWriterAndLinkMetadata(Profile writer, Long linkMetadata);
+	boolean existsByWriterAndUrl(Profile writer, String url);
 
 	/* 피드 북마크 조회 */
 	Page<Bookmark> findBookmarks(BookmarkFindCond findCond, Pageable pageable);

--- a/src/main/java/com/meoguri/linkocean/domain/bookmark/persistence/CustomBookmarkRepositoryImpl.java
+++ b/src/main/java/com/meoguri/linkocean/domain/bookmark/persistence/CustomBookmarkRepositoryImpl.java
@@ -39,12 +39,12 @@ public class CustomBookmarkRepositoryImpl extends Querydsl4RepositorySupport imp
 	}
 
 	@Override
-	public boolean existsByWriterAndLinkMetadata(final Profile writer, final Long linkMetadataId) {
+	public boolean existsByWriterAndUrl(final Profile writer, final String url) {
 		return selectOne()
 			.from(bookmark)
 			.where(
 				writerIdEq(writer.getId()),
-				linMetadataIdEq(linkMetadataId),
+				bookmark.url.eq(url),
 				registered()
 			).fetchFirst() != null;
 	}

--- a/src/main/java/com/meoguri/linkocean/domain/bookmark/service/BookmarkServiceImpl.java
+++ b/src/main/java/com/meoguri/linkocean/domain/bookmark/service/BookmarkServiceImpl.java
@@ -214,7 +214,12 @@ public class BookmarkServiceImpl implements BookmarkService {
 
 		/* 추가 정보 조회 */
 		final Set<LinkMetadata> linkMetadataSet = findLinkMetadataByIdQuery.findByIds(
-			bookmarks.stream().map(BaseIdEntity::getId).collect(toList()));
+			bookmarks.stream()
+				.map(Bookmark::getLinkMetadataId)
+				.filter(Optional::isPresent)
+				.map(Optional::get)
+				.collect(toList()));
+
 		final List<Boolean> isFavorites = profile.isFavoriteBookmarks(bookmarks);
 		final List<Boolean> isFollows = profile.isFollows(writers);
 

--- a/src/main/java/com/meoguri/linkocean/domain/bookmark/service/BookmarkServiceImpl.java
+++ b/src/main/java/com/meoguri/linkocean/domain/bookmark/service/BookmarkServiceImpl.java
@@ -59,10 +59,7 @@ public class BookmarkServiceImpl implements BookmarkService {
 	private final FindLinkMetadataByUrlQuery findLinkMetadataByUrlQuery;
 	private final FindLinkMetadataByIdQuery findLinkMetadataByIdQuery;
 
-	/**
-	 * 북마크 등록
-	 * - 북마크 등록을 위해 항상 linkMetadata 가 먼저 저장 되어 있어야 한다.
-	 */
+	/* 북마크 등록 */
 	@Transactional
 	@Override
 	public long registerBookmark(final RegisterBookmarkCommand command) {
@@ -71,10 +68,11 @@ public class BookmarkServiceImpl implements BookmarkService {
 
 		/* 연관 필드 조회 */
 		final Profile writer = profileQueryService.findById(writerId);
-		final LinkMetadata linkMetadata = findLinkMetadataByUrlQuery.findByUrl(url);
+		final Long linkMetadataId = findLinkMetadataByUrlQuery.findByUrl(url)
+			.map(BaseIdEntity::getId).orElse(null);
 
 		/* 비즈니스 로직 검증 - 사용자는 [url]당 하나의 북마크를 가질 수 있다 */
-		final boolean exists = bookmarkRepository.existsByWriterAndLinkMetadata(writer, linkMetadata.getId());
+		final boolean exists = bookmarkRepository.existsByWriterAndUrl(writer, url);
 		checkUniqueConstraint(exists, "이미 해당 url 의 북마크를 가지고 있습니다");
 
 		/* 태그 조회/저장 */
@@ -83,7 +81,7 @@ public class BookmarkServiceImpl implements BookmarkService {
 		/* 북마크 등록 진행 */
 		return bookmarkRepository.save(new Bookmark(
 			writer,
-			linkMetadata.getId(),
+			linkMetadataId,
 			command.getTitle(),
 			command.getMemo(),
 			command.getOpenType(),
@@ -139,7 +137,9 @@ public class BookmarkServiceImpl implements BookmarkService {
 		final boolean follow = profileQueryService.findProfileFetchFollows(profileId).isFollow(writer);
 		final boolean favorite = profileQueryService.findProfileFetchFavoriteById(profileId).isFavorite(bookmark);
 
-		final LinkMetadata linkMetadata = findLinkMetadataByIdQuery.findById(bookmark.getLinkMetadataId());
+		final String linkMetaDataImage = bookmark.getLinkMetadataId()
+			.map(linkMetadataId -> findLinkMetadataByIdQuery.findById(linkMetadataId).getImage())
+			.orElse(DEFAULT_IMAGE);
 
 		final Map<ReactionType, Long> reactionCountMap = bookmark.countReactionGroup();
 		final Map<ReactionType, Boolean> reactionMap = bookmark.checkReaction(profileId);
@@ -150,7 +150,7 @@ public class BookmarkServiceImpl implements BookmarkService {
 			bookmarkId,
 			bookmark.getTitle(),
 			bookmark.getUrl(),
-			linkMetadata.getImage(),
+			linkMetaDataImage,
 			bookmark.getCategory(),
 			bookmark.getMemo(),
 			bookmark.getOpenType(),
@@ -186,7 +186,11 @@ public class BookmarkServiceImpl implements BookmarkService {
 
 		/* 추가 정보 조회 */
 		final Set<LinkMetadata> linkMetadataSet = findLinkMetadataByIdQuery.findByIds(
-			bookmarks.stream().map(BaseIdEntity::getId).collect(toList()));
+			bookmarks.stream()
+				.map(Bookmark::getLinkMetadataId)
+				.filter(Optional::isPresent)
+				.map(Optional::get)
+				.collect(toList()));
 
 		final Profile currentUserProfile = profileQueryService.findProfileFetchFavoriteById(profileId);
 		final List<Boolean> isFavorites = currentUserProfile.isFavoriteBookmarks(bookmarks);
@@ -327,7 +331,7 @@ public class BookmarkServiceImpl implements BookmarkService {
 	 */
 	private String getLinkMetadataImage(final Bookmark bookmark, final Set<LinkMetadata> linkMetadataSet) {
 		return linkMetadataSet.stream()
-			.filter(linkMetadata -> linkMetadata.getId().equals(bookmark.getLinkMetadataId()))
+			.filter(linkMetadata -> linkMetadata.getId().equals(bookmark.getLinkMetadataId().orElse(null)))
 			.map(LinkMetadata::getImage)
 			.findFirst().orElse(DEFAULT_IMAGE);
 	}

--- a/src/main/java/com/meoguri/linkocean/domain/linkmetadata/persistence/FindLinkMetadataByUrlQuery.java
+++ b/src/main/java/com/meoguri/linkocean/domain/linkmetadata/persistence/FindLinkMetadataByUrlQuery.java
@@ -1,11 +1,10 @@
 package com.meoguri.linkocean.domain.linkmetadata.persistence;
 
-import static java.lang.String.*;
+import java.util.Optional;
 
 import com.meoguri.linkocean.annotation.Query;
 import com.meoguri.linkocean.domain.linkmetadata.entity.LinkMetadata;
 import com.meoguri.linkocean.domain.linkmetadata.entity.vo.Link;
-import com.meoguri.linkocean.exception.LinkoceanRuntimeException;
 
 import lombok.RequiredArgsConstructor;
 
@@ -15,8 +14,7 @@ public class FindLinkMetadataByUrlQuery {
 
 	private final LinkMetadataRepository linkMetadataRepository;
 
-	public LinkMetadata findByUrl(final String url) {
-		return linkMetadataRepository.findByLink(new Link(url))
-			.orElseThrow(() -> new LinkoceanRuntimeException(format("no such linkmetadata with url : %s", url)));
+	public Optional<LinkMetadata> findByUrl(final String url) {
+		return linkMetadataRepository.findByLink(new Link(url));
 	}
 }

--- a/src/main/resources/db/migration/V021__Alter_bookmark.sql
+++ b/src/main/resources/db/migration/V021__Alter_bookmark.sql
@@ -1,0 +1,1 @@
+alter table bookmark modify link_metadata_id bigint;

--- a/src/test/java/com/meoguri/linkocean/controller/bookmark/BookmarkControllerTest.java
+++ b/src/test/java/com/meoguri/linkocean/controller/bookmark/BookmarkControllerTest.java
@@ -1,6 +1,7 @@
 package com.meoguri.linkocean.controller.bookmark;
 
 import static com.meoguri.linkocean.domain.user.entity.vo.OAuthType.*;
+import static java.util.Collections.*;
 import static org.hamcrest.Matchers.*;
 import static org.springframework.http.HttpHeaders.*;
 import static org.springframework.http.MediaType.*;
@@ -13,6 +14,7 @@ import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.springframework.test.web.servlet.ResultActions;
 
 import com.meoguri.linkocean.controller.bookmark.dto.RegisterBookmarkRequest;
 import com.meoguri.linkocean.controller.bookmark.dto.UpdateBookmarkRequest;
@@ -32,7 +34,7 @@ class BookmarkControllerTest extends BaseControllerTest {
 
 	@Test
 	void 북마크_등록_Api_성공() throws Exception {
-
+		//given
 		final String title = "title1";
 		final String memo = "memo";
 		final String category = "인문";
@@ -48,6 +50,27 @@ class BookmarkControllerTest extends BaseControllerTest {
 				.content(createJson(registerBookmarkRequest)))
 
 			//then
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.id").exists())
+			.andDo(print());
+	}
+
+	@Test
+	void 북마크_등록_Api_성공_링크_메타데이터_없음() throws Exception {
+		//given
+		final String noLinkMetaDataUrl = "https://noLinkMetadata.com";
+
+		final RegisterBookmarkRequest registerBookmarkRequest =
+			new RegisterBookmarkRequest(noLinkMetaDataUrl, "title", "memo", "인문", "all", emptyList());
+
+		//when
+		final ResultActions perform = mockMvc.perform(post(basePath)
+			.header(AUTHORIZATION, token)
+			.contentType(APPLICATION_JSON)
+			.content(createJson(registerBookmarkRequest)));
+
+		//then
+		perform
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.id").exists())
 			.andDo(print());

--- a/src/test/java/com/meoguri/linkocean/domain/bookmark/entity/BookmarkTest.java
+++ b/src/test/java/com/meoguri/linkocean/domain/bookmark/entity/BookmarkTest.java
@@ -27,7 +27,7 @@ class BookmarkTest extends BaseEntityTest {
 		value = {"null, null", "null, title", "memo, null", "memo, title"},
 		nullValues = {"null"}
 	)
-	void 북마크_생성_성공(final String memo, final String title) {
+	void 북마크_생성_성공_제목과_메모는_null_가능(final String memo, final String title) {
 		//given
 		final Profile profile = createProfile();
 		final Long linkMetadataId = createLinkMetadata().getId();
@@ -44,7 +44,7 @@ class BookmarkTest extends BaseEntityTest {
 			.extracting(
 				Bookmark::getWriter,
 				Bookmark::getTitle,
-				Bookmark::getLinkMetadataId,
+				b -> b.getLinkMetadataId().orElse(null),
 				Bookmark::getMemo,
 				Bookmark::getCategory,
 				Bookmark::getOpenType
@@ -53,6 +53,23 @@ class BookmarkTest extends BaseEntityTest {
 		assertThat(bookmark)
 			.extracting(Bookmark::getCreatedAt, Bookmark::getUpdatedAt)
 			.doesNotContainNull();
+	}
+
+	@Test
+	void 북마크_생성_성공_링크_메타데이터가_없어도_된다() {
+		//given
+		final Long nullLinkMetadataId = null;
+
+		//when
+		final Bookmark newBookmark = new Bookmark(
+			createProfile(),
+			nullLinkMetadataId,
+			"title", "memo", ALL, IT, "https://hello.co.kr",
+			createTagIds());
+
+		//then
+		assertThat(newBookmark).isNotNull();
+		assertThat(newBookmark.getLinkMetadataId()).isEmpty();
 	}
 
 	@Test

--- a/src/test/java/com/meoguri/linkocean/domain/bookmark/persistence/CustomBookmarkRepositoryImplTest.java
+++ b/src/test/java/com/meoguri/linkocean/domain/bookmark/persistence/CustomBookmarkRepositoryImplTest.java
@@ -67,18 +67,17 @@ class CustomBookmarkRepositoryImplTest extends BasePersistenceTest {
 	}
 
 	@Test
-	void existsByWriterAndLinkMetadata_성공() {
+	void existsByWriterAndUrl_성공() {
 		//given
 		profile = 사용자_프로필_동시_저장("crush@gmail.com", NAVER, "crush", IT);
 		final LinkMetadata linkMetadata = 링크_메타데이터_저장("www.google.com", "구글", "google.png");
 		북마크_저장(profile, linkMetadata, "www.google.com");
 
 		//when
-		final boolean exists =
-			bookmarkRepository.existsByWriterAndLinkMetadata(profile, linkMetadata.getId());
+		final boolean exist = bookmarkRepository.existsByWriterAndUrl(profile, "www.google.com");
 
 		//then
-		assertThat(exists).isEqualTo(true);
+		assertThat(exist).isTrue();
 	}
 
 	@Nested

--- a/src/test/java/com/meoguri/linkocean/domain/bookmark/service/BookmarkServiceImplTest.java
+++ b/src/test/java/com/meoguri/linkocean/domain/bookmark/service/BookmarkServiceImplTest.java
@@ -94,17 +94,17 @@ class BookmarkServiceImplTest extends BaseServiceTest {
 
 			//when then
 			assertThatLinkoceanRuntimeException()
-				.isThrownBy(() -> 북마크_등록(invalidId, "www.youtube.com"));
+				.isThrownBy(() -> 북마크_링크_메타데이터_동시_등록(invalidId, "www.youtube.com"));
 		}
 
 		@Test
 		void 북마크_등록_실패_중복_url() {
 			//given
-			북마크_등록(profileId, "www.youtube.com");
+			북마크_링크_메타데이터_동시_등록(profileId, "www.youtube.com");
 
 			//when then
 			assertThatIllegalArgumentException()
-				.isThrownBy(() -> 북마크_등록(profileId, "www.youtube.com"));
+				.isThrownBy(() -> 북마크_링크_메타데이터_동시_등록(profileId, "www.youtube.com"));
 		}
 
 	}
@@ -118,7 +118,7 @@ class BookmarkServiceImplTest extends BaseServiceTest {
 		@BeforeEach
 		void setUp() {
 			profileId = 사용자_프로필_동시_등록("haha@gmail.com", GOOGLE, "haha", IT);
-			bookmarkId = 북마크_등록(profileId, "www.youtube.com");
+			bookmarkId = 북마크_링크_메타데이터_동시_등록(profileId, "www.youtube.com");
 		}
 
 		@Test
@@ -173,7 +173,7 @@ class BookmarkServiceImplTest extends BaseServiceTest {
 		void 북마크_업데이트_실패_다른_사용자의_북마크() {
 			//given
 			final long crushProfileId = 사용자_프로필_동시_등록("crush@gmail.com", GOOGLE, "crush", IT);
-			final long crushBookmarkId = 북마크_등록(crushProfileId, "www.linkocean.com");
+			final long crushBookmarkId = 북마크_링크_메타데이터_동시_등록(crushProfileId, "www.linkocean.com");
 
 			final UpdateBookmarkCommand command = createUpdateBookmarkCommand(profileId, crushBookmarkId);
 
@@ -204,7 +204,7 @@ class BookmarkServiceImplTest extends BaseServiceTest {
 		@BeforeEach
 		void setUp() {
 			profileId = 사용자_프로필_동시_등록("haha@gmail.com", GOOGLE, "haha", IT);
-			bookmarkId = 북마크_등록(profileId, "www.youtube.com");
+			bookmarkId = 북마크_링크_메타데이터_동시_등록(profileId, "www.youtube.com");
 		}
 
 		@Test
@@ -231,7 +231,7 @@ class BookmarkServiceImplTest extends BaseServiceTest {
 		void 북마크_삭제_실패_다른_사용자의_북마크_삭제_시도() {
 			//given
 			final long crushProfileId = 사용자_프로필_동시_등록("crush@gmail.com", GOOGLE, "crush", IT);
-			final long crushBookmarkId = 북마크_등록(crushProfileId, "www.linkocean.com");
+			final long crushBookmarkId = 북마크_링크_메타데이터_동시_등록(crushProfileId, "www.linkocean.com");
 
 			//when then
 			assertThatLinkoceanRuntimeException()
@@ -248,7 +248,7 @@ class BookmarkServiceImplTest extends BaseServiceTest {
 		@BeforeEach
 		void setUp() {
 			profileId = 사용자_프로필_동시_등록("haha@gmail.com", GOOGLE, "haha", IT);
-			bookmarkId = 북마크_등록(profileId, "www.youtube.com");
+			bookmarkId = 북마크_링크_메타데이터_동시_등록(profileId, "www.youtube.com");
 		}
 
 		@Test
@@ -301,9 +301,10 @@ class BookmarkServiceImplTest extends BaseServiceTest {
 		@BeforeEach
 		void setUp() {
 			profileId1 = 사용자_프로필_동시_등록("haha@gmail.com", GOOGLE, "haha", IT);
-			bookmarkId1 = 북마크_등록(profileId1, "http://www.naver.com", "title1", null, IT, ALL, "tag1", "tag2");
-			bookmarkId2 = 북마크_등록(profileId1, "http://www.daum.com", "title2", null, IT, PARTIAL, "tag2");
-			bookmarkId3 = 북마크_등록(profileId1, "http://www.kakao.com", "title3", null, HOME, PRIVATE, "tag1");
+			bookmarkId1 = 북마크_링크_메타데이터_동시_등록(profileId1, "http://www.naver.com", "title1", null, IT, ALL, "tag1",
+				"tag2");
+			bookmarkId2 = 북마크_링크_메타데이터_동시_등록(profileId1, "http://www.daum.com", "title2", null, IT, PARTIAL, "tag2");
+			bookmarkId3 = 북마크_링크_메타데이터_동시_등록(profileId1, "http://www.kakao.com", "title3", null, HOME, PRIVATE, "tag1");
 
 			profileId2 = 사용자_프로필_동시_등록("crush@gmail.com", GOOGLE, "crush", IT);
 		}
@@ -417,17 +418,17 @@ class BookmarkServiceImplTest extends BaseServiceTest {
 			profileId3 = 사용자_프로필_동시_등록("user3@gmail.com", GOOGLE, "user3", IT);
 
 			// 링크 메타 데이터 3개 셋업
-			북마크_등록(profileId3, "www.github.com", PRIVATE);
-			북마크_등록(profileId3, "www.kakao.com", PRIVATE);
-			bookmarkId10 = 북마크_등록(profileId3, "www.naver.com", ALL);
+			북마크_링크_메타데이터_동시_등록(profileId3, "www.github.com", PRIVATE);
+			북마크_링크_메타데이터_동시_등록(profileId3, "www.kakao.com", PRIVATE);
+			bookmarkId10 = 북마크_링크_메타데이터_동시_등록(profileId3, "www.naver.com", ALL);
 
-			북마크_등록(profileId2, "www.github.com", PRIVATE);
-			bookmarkId8 = 북마크_등록(profileId2, "www.kakao.com", PARTIAL);
-			bookmarkId7 = 북마크_등록(profileId2, "www.naver.com", ALL);
+			북마크_링크_메타데이터_동시_등록(profileId2, "www.github.com", PRIVATE);
+			bookmarkId8 = 북마크_링크_메타데이터_동시_등록(profileId2, "www.kakao.com", PARTIAL);
+			bookmarkId7 = 북마크_링크_메타데이터_동시_등록(profileId2, "www.naver.com", ALL);
 
-			bookmarkId6 = 북마크_등록(profileId1, "www.github.com", PRIVATE);
-			bookmarkId5 = 북마크_등록(profileId1, "www.kakao.com", PARTIAL);
-			bookmarkId4 = 북마크_등록(profileId1, "www.naver.com", ALL);
+			bookmarkId6 = 북마크_링크_메타데이터_동시_등록(profileId1, "www.github.com", PRIVATE);
+			bookmarkId5 = 북마크_링크_메타데이터_동시_등록(profileId1, "www.kakao.com", PARTIAL);
+			bookmarkId4 = 북마크_링크_메타데이터_동시_등록(profileId1, "www.naver.com", ALL);
 
 			팔로우(profileId1, profileId2);
 		}
@@ -508,7 +509,7 @@ class BookmarkServiceImplTest extends BaseServiceTest {
 	void 중복_url_확인_성공() {
 		//given
 		final long profileId = 사용자_프로필_동시_등록("haha@gmail.com", GOOGLE, "haha", IT);
-		final long bookmarkId = 북마크_등록(profileId, "www.google.com");
+		final long bookmarkId = 북마크_링크_메타데이터_동시_등록(profileId, "www.google.com");
 
 		//when
 		final Optional<Long> duplicated = bookmarkService.getBookmarkIdIfExist(profileId, "www.google.com");
@@ -524,9 +525,9 @@ class BookmarkServiceImplTest extends BaseServiceTest {
 		//given
 		final long profileId = 사용자_프로필_동시_등록("haha@gmail.com", GOOGLE, "haha", IT);
 
-		북마크_등록(profileId, "www.naver.com", "tag1", "tag2", "tag3");
-		북마크_등록(profileId, "www.google.com", "tag1", "tag2");
-		북마크_등록(profileId, "www.prgrms.com", "tag1");
+		북마크_링크_메타데이터_동시_등록(profileId, "www.naver.com", "tag1", "tag2", "tag3");
+		북마크_링크_메타데이터_동시_등록(profileId, "www.google.com", "tag1", "tag2");
+		북마크_링크_메타데이터_동시_등록(profileId, "www.prgrms.com", "tag1");
 
 		//when
 		final List<GetUsedTagWithCountResult> result = bookmarkService.getUsedTagsWithCount(profileId);

--- a/src/test/java/com/meoguri/linkocean/domain/bookmark/service/BookmarkServiceImplTest.java
+++ b/src/test/java/com/meoguri/linkocean/domain/bookmark/service/BookmarkServiceImplTest.java
@@ -5,6 +5,7 @@ import static com.meoguri.linkocean.domain.bookmark.entity.vo.OpenType.*;
 import static com.meoguri.linkocean.domain.bookmark.entity.vo.ReactionType.*;
 import static com.meoguri.linkocean.domain.user.entity.vo.OAuthType.*;
 import static com.meoguri.linkocean.test.support.common.Assertions.*;
+import static java.util.Collections.*;
 import static org.assertj.core.api.Assertions.*;
 
 import java.util.List;
@@ -70,6 +71,20 @@ class BookmarkServiceImplTest extends BaseServiceTest {
 			assertThat(result.getProfile().getUsername()).isEqualTo("haha");
 			assertThat(result.getProfile().getImage()).isEqualTo(null);
 			assertThat(result.getProfile().isFollow()).isEqualTo(false);
+		}
+
+		@Test
+		void 북마크_등록_성공_링크_메타데이터_없어도_됨() {
+			//given
+			String noLinkMetadataUrl = "https://noLinkMetadata.com";
+			final RegisterBookmarkCommand command = new RegisterBookmarkCommand(profileId, noLinkMetadataUrl,
+				"title", "memo", IT, ALL, emptyList());
+
+			//when
+			final long registeredBookmarkId = bookmarkService.registerBookmark(command);
+
+			//then
+			assertThat(북마크_상세_조회(profileId, registeredBookmarkId)).isNotNull();
 		}
 
 		@Test

--- a/src/test/java/com/meoguri/linkocean/domain/bookmark/service/CategoryServiceImplTest.java
+++ b/src/test/java/com/meoguri/linkocean/domain/bookmark/service/CategoryServiceImplTest.java
@@ -29,12 +29,12 @@ class CategoryServiceImplTest extends BaseServiceTest {
 	@Test
 	void 사용자가_작성한_북마크가있는_카테고리_조회_성공() {
 		//given
-		북마크_등록(profileId, "www.naver.com", IT);
-		북마크_등록(profileId, "www.prgrms.com", IT);
-		북마크_등록(profileId, "www.daum.com", IT);
-		북마크_등록(profileId, "www.hello.com", SOCIAL);
-		북마크_등록(profileId, "www.linkocean.com", SOCIAL);
-		북마크_등록(profileId, "www.jacob.com", HEALTH);
+		북마크_링크_메타데이터_동시_등록(profileId, "www.naver.com", IT);
+		북마크_링크_메타데이터_동시_등록(profileId, "www.prgrms.com", IT);
+		북마크_링크_메타데이터_동시_등록(profileId, "www.daum.com", IT);
+		북마크_링크_메타데이터_동시_등록(profileId, "www.hello.com", SOCIAL);
+		북마크_링크_메타데이터_동시_등록(profileId, "www.linkocean.com", SOCIAL);
+		북마크_링크_메타데이터_동시_등록(profileId, "www.jacob.com", HEALTH);
 
 		//when
 		final List<Category> categories = categoryService.getUsedCategories(profileId);

--- a/src/test/java/com/meoguri/linkocean/domain/bookmark/service/ReactionServiceImplTest.java
+++ b/src/test/java/com/meoguri/linkocean/domain/bookmark/service/ReactionServiceImplTest.java
@@ -24,7 +24,7 @@ class ReactionServiceImplTest extends BaseServiceTest {
 	@BeforeEach
 	void setUp() {
 		profileId = 사용자_프로필_동시_등록("haha@gmail.com", GOOGLE, "haha", IT);
-		bookmarkId = 북마크_등록(profileId, "www.youtube.com");
+		bookmarkId = 북마크_링크_메타데이터_동시_등록(profileId, "www.youtube.com");
 	}
 
 	@Test

--- a/src/test/java/com/meoguri/linkocean/domain/linkmetadata/persistence/FindLinkMetadataByLinkQueryTest.java
+++ b/src/test/java/com/meoguri/linkocean/domain/linkmetadata/persistence/FindLinkMetadataByLinkQueryTest.java
@@ -1,7 +1,8 @@
 package com.meoguri.linkocean.domain.linkmetadata.persistence;
 
-import static com.meoguri.linkocean.test.support.common.Assertions.*;
 import static org.assertj.core.api.Assertions.*;
+
+import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -23,16 +24,18 @@ class FindLinkMetadataByLinkQueryTest extends BasePersistenceTest {
 		final LinkMetadata savedLinkMetadata = 링크_메타데이터_저장(saveLink, "네이버", "naver.png");
 
 		//when
-		final LinkMetadata foundLinkMetadata = query.findByUrl("naver.com");
+		final Optional<LinkMetadata> oFoundLinkMetadata = query.findByUrl("naver.com");
 
 		//then
-		assertThat(foundLinkMetadata).isEqualTo(savedLinkMetadata);
+		assertThat(oFoundLinkMetadata).hasValue(savedLinkMetadata);
 	}
 
 	@Test
 	void 존재하지_않는_url_조회() {
-		//when then
-		assertThatLinkoceanRuntimeException()
-			.isThrownBy(() -> query.findByUrl("invalid.com"));
+		//when
+		final Optional<LinkMetadata> oFoundLinkMetadata = query.findByUrl("invalid.com");
+
+		// then
+		assertThat(oFoundLinkMetadata).isEmpty();
 	}
 }

--- a/src/test/java/com/meoguri/linkocean/domain/notification/service/NotificationServiceImplTest.java
+++ b/src/test/java/com/meoguri/linkocean/domain/notification/service/NotificationServiceImplTest.java
@@ -32,7 +32,7 @@ class NotificationServiceImplTest extends BaseServiceTest {
 		receiver1ProfileId = 사용자_프로필_동시_등록("receiver1@gamil.com", GOOGLE, "receiver1", IT);
 		receiver2ProfileId = 사용자_프로필_동시_등록("receiver2@gamil.com", GOOGLE, "receiver2", IT);
 
-		bookmarkId = 북마크_등록(senderProfileId, "www.google.com", "구글", "메모", IT, ALL);
+		bookmarkId = 북마크_링크_메타데이터_동시_등록(senderProfileId, "www.google.com", "구글", "메모", IT, ALL);
 
 		팔로우(receiver1ProfileId, senderProfileId);
 		팔로우(receiver2ProfileId, senderProfileId);

--- a/src/test/java/com/meoguri/linkocean/domain/profile/command/service/FavoriteServiceImplTest.java
+++ b/src/test/java/com/meoguri/linkocean/domain/profile/command/service/FavoriteServiceImplTest.java
@@ -31,8 +31,8 @@ class FavoriteServiceImplTest extends BaseServiceTest {
 		log.info("== set up start ==");
 
 		profileId = 사용자_프로필_동시_등록("haha@gmail.com", GOOGLE, "haha", IT, ART);
-		bookmarkId1 = 북마크_등록(profileId, "www.google.com");
-		bookmarkId2 = 북마크_등록(profileId, "www.naver.com");
+		bookmarkId1 = 북마크_링크_메타데이터_동시_등록(profileId, "www.google.com");
+		bookmarkId2 = 북마크_링크_메타데이터_동시_등록(profileId, "www.naver.com");
 
 		em.flush();
 		em.clear();

--- a/src/test/java/com/meoguri/linkocean/test/support/domain/service/BaseServiceTest.java
+++ b/src/test/java/com/meoguri/linkocean/test/support/domain/service/BaseServiceTest.java
@@ -2,6 +2,7 @@ package com.meoguri.linkocean.test.support.domain.service;
 
 import static com.meoguri.linkocean.domain.bookmark.entity.vo.OpenType.*;
 import static com.meoguri.linkocean.domain.bookmark.entity.vo.ReactionType.*;
+import static java.util.Collections.*;
 import static java.util.stream.Collectors.*;
 
 import java.util.Arrays;
@@ -102,6 +103,12 @@ public abstract class BaseServiceTest {
 
 	protected void 즐겨찾기(final long profileId, final long bookmarkId) {
 		favoriteService.favorite(profileId, bookmarkId);
+	}
+
+	protected long 북마크_등록(final long writerId, final String url, final OpenType openType) {
+		return bookmarkService.registerBookmark(
+			new RegisterBookmarkCommand(writerId, url, "title", "memo", Category.IT, openType, emptyList())
+		);
 	}
 
 	protected long 북마크_링크_메타데이터_동시_등록(final long writerId, final String url, final OpenType openType) {

--- a/src/test/java/com/meoguri/linkocean/test/support/domain/service/BaseServiceTest.java
+++ b/src/test/java/com/meoguri/linkocean/test/support/domain/service/BaseServiceTest.java
@@ -104,21 +104,22 @@ public abstract class BaseServiceTest {
 		favoriteService.favorite(profileId, bookmarkId);
 	}
 
-	protected long 북마크_등록(final long writerId, final String url, final OpenType openType) {
-		return 북마크_등록(writerId, url, null, null, null, openType);
+	protected long 북마크_링크_메타데이터_동시_등록(final long writerId, final String url, final OpenType openType) {
+		return 북마크_링크_메타데이터_동시_등록(writerId, url, null, null, null, openType);
 	}
 
-	protected long 북마크_등록(final long writerId, final String url, final String... tags) {
-		return 북마크_등록(writerId, url, null, tags);
+	protected long 북마크_링크_메타데이터_동시_등록(final long writerId, final String url, final String... tags) {
+		return 북마크_링크_메타데이터_동시_등록(writerId, url, null, tags);
 	}
 
-	protected long 북마크_등록(final long writerId, final String url, final Category category, final String... tags) {
+	protected long 북마크_링크_메타데이터_동시_등록(final long writerId, final String url, final Category category,
+		final String... tags) {
 		final String title = linkMetadataService.obtainTitle(url);
 
-		return 북마크_등록(writerId, url, title, null, category, ALL, tags);
+		return 북마크_링크_메타데이터_동시_등록(writerId, url, title, null, category, ALL, tags);
 	}
 
-	protected long 북마크_등록(
+	protected long 북마크_링크_메타데이터_동시_등록(
 		final long writerId,
 		final String url,
 		final String title,


### PR DESCRIPTION
<!-- PR 제목 양식 예시: [LO-N] 회원 기능 도메인 -->

## 🛠️ 작업 내용
- 북마크 생성 정책 변경

## 🗨️ 기타
<!-- PR 포인트 혹은 궁금한 점 등등 적어주시면 됩니다. 없으시면 지워주세요 -->
- 북마크 생성시 북마크 url에 링크 메타데이터가 존재하지 않아도 저장 가능하도록 변경한 정책을 코드에 반영했습니다.
- 정책이 변경되면서 변경된 부분입니다.
  - 북마크 테이블 link_metadata_id에 not null 제약 조건 제거
  - 북마크 엔티티 linkmetadata getter optional 추가
  - 북마크 생성 서비스 로직 변경
  - 북마크 상세 조회, 목록 조회에서 북마크 링크 메타데이터 존재 하지 않으면 서비스에서 DEFAULT_IMAGE 값 넣어주기
  - 관련 시나리오 테스트 추가

## 😎 리뷰어
@ndy2 , @jk05018 , @NewEgoDoc, @hyuk0309
