### PR TITLE
[LO-208] 링크 메타데이터 정책 변경

### DIFF
--- a/src/main/java/com/meoguri/linkocean/controller/linkmetadata/LinkMetadataController.java
+++ b/src/main/java/com/meoguri/linkocean/controller/linkmetadata/LinkMetadataController.java
@@ -23,6 +23,7 @@ public class LinkMetadataController {
 	public Map<String, Object> obtainTitle(
 		final @RequestBody Map<String, String> request
 	) {
-		return Map.of("title", linkMetadataService.obtainTitle(request.get("url")));
+		String title = linkMetadataService.obtainTitle(request.get("url"));
+		return Map.of("title", title == null ? "제목 없음" : title);
 	}
 }

--- a/src/main/java/com/meoguri/linkocean/domain/bookmark/service/BookmarkServiceImpl.java
+++ b/src/main/java/com/meoguri/linkocean/domain/bookmark/service/BookmarkServiceImpl.java
@@ -2,7 +2,7 @@ package com.meoguri.linkocean.domain.bookmark.service;
 
 import static com.meoguri.linkocean.domain.bookmark.service.dto.GetDetailedBookmarkResult.*;
 import static com.meoguri.linkocean.exception.Preconditions.*;
-import static com.meoguri.linkocean.infrastructure.jsoup.JsoupLinkMetadataService.*;
+import static com.meoguri.linkocean.infrastructure.jsoup.JsoupGetLinkMetadataService.*;
 import static java.lang.String.*;
 import static java.util.stream.Collectors.*;
 

--- a/src/main/java/com/meoguri/linkocean/domain/linkmetadata/service/GetLinkMetadata.java
+++ b/src/main/java/com/meoguri/linkocean/domain/linkmetadata/service/GetLinkMetadata.java
@@ -1,0 +1,8 @@
+package com.meoguri.linkocean.domain.linkmetadata.service;
+
+import com.meoguri.linkocean.domain.linkmetadata.service.dto.GetLinkMetadataResult;
+
+public interface GetLinkMetadata {
+
+	GetLinkMetadataResult getLinkMetadata(String url);
+}

--- a/src/main/java/com/meoguri/linkocean/domain/linkmetadata/service/LinkMetadataServiceImpl.java
+++ b/src/main/java/com/meoguri/linkocean/domain/linkmetadata/service/LinkMetadataServiceImpl.java
@@ -27,11 +27,20 @@ public class LinkMetadataServiceImpl implements LinkMetadataService {
 	@Transactional
 	@Override
 	public String obtainTitle(final String url) {
-		return linkMetadataRepository.findTitleByLink(new Link(url)).orElseGet(() -> {
+
+		return linkMetadataRepository.findTitleByLink(new Link(url))
+			.orElseGet(() -> saveLinkMetadataAndReturnTitle(url));
+	}
+
+	/* 링크 메타데이터가 존재하면 저장하고, 제목을 반환한다 */
+	private String saveLinkMetadataAndReturnTitle(final String url) {
+		try {
 			final SearchLinkMetadataResult result = jsoupLinkMetadataService.search(url);
 			linkMetadataRepository.save(new LinkMetadata(url, result.getTitle(), result.getImage()));
 			return result.getTitle();
-		});
+		} catch (IllegalArgumentException e) {
+			return null;
+		}
 	}
 
 	@Transactional

--- a/src/main/java/com/meoguri/linkocean/domain/linkmetadata/service/LinkMetadataServiceImpl.java
+++ b/src/main/java/com/meoguri/linkocean/domain/linkmetadata/service/LinkMetadataServiceImpl.java
@@ -31,7 +31,7 @@ public class LinkMetadataServiceImpl implements LinkMetadataService {
 			.orElseGet(() -> saveLinkMetadataAndReturnTitle(url));
 	}
 
-	/* 링크 메타데이터가 존재하면 저장하고 제목을 반환한다 */
+	/* url의 링크 메타데이터가 존재하면 db에 저장하고 제목을 반환한다 */
 	private String saveLinkMetadataAndReturnTitle(final String url) {
 		try {
 			final GetLinkMetadataResult result = getLinkMetadata.getLinkMetadata(url);

--- a/src/main/java/com/meoguri/linkocean/domain/linkmetadata/service/LinkMetadataServiceImpl.java
+++ b/src/main/java/com/meoguri/linkocean/domain/linkmetadata/service/LinkMetadataServiceImpl.java
@@ -8,8 +8,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.meoguri.linkocean.domain.linkmetadata.entity.LinkMetadata;
 import com.meoguri.linkocean.domain.linkmetadata.entity.vo.Link;
 import com.meoguri.linkocean.domain.linkmetadata.persistence.LinkMetadataRepository;
-import com.meoguri.linkocean.infrastructure.jsoup.JsoupLinkMetadataService;
-import com.meoguri.linkocean.infrastructure.jsoup.SearchLinkMetadataResult;
+import com.meoguri.linkocean.domain.linkmetadata.service.dto.GetLinkMetadataResult;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -20,7 +19,7 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class LinkMetadataServiceImpl implements LinkMetadataService {
 
-	private final JsoupLinkMetadataService jsoupLinkMetadataService;
+	private final GetLinkMetadata getLinkMetadata;
 
 	private final LinkMetadataRepository linkMetadataRepository;
 
@@ -32,10 +31,10 @@ public class LinkMetadataServiceImpl implements LinkMetadataService {
 			.orElseGet(() -> saveLinkMetadataAndReturnTitle(url));
 	}
 
-	/* 링크 메타데이터가 존재하면 저장하고, 제목을 반환한다 */
+	/* 링크 메타데이터가 존재하면 저장하고 제목을 반환한다 */
 	private String saveLinkMetadataAndReturnTitle(final String url) {
 		try {
-			final SearchLinkMetadataResult result = jsoupLinkMetadataService.search(url);
+			final GetLinkMetadataResult result = getLinkMetadata.getLinkMetadata(url);
 			linkMetadataRepository.save(new LinkMetadata(url, result.getTitle(), result.getImage()));
 			return result.getTitle();
 		} catch (IllegalArgumentException e) {
@@ -49,11 +48,10 @@ public class LinkMetadataServiceImpl implements LinkMetadataService {
 		final Slice<LinkMetadata> slice = linkMetadataRepository.findBy(pageable);
 
 		slice.forEach(link -> {
-			final SearchLinkMetadataResult result = jsoupLinkMetadataService.search(Link.toString(link.getLink()));
+			final GetLinkMetadataResult result = getLinkMetadata.getLinkMetadata(Link.toString(link.getLink()));
 			link.update(result.getTitle(), result.getImage());
 		});
 
 		return slice.hasNext() ? slice.nextPageable() : null;
 	}
-
 }

--- a/src/main/java/com/meoguri/linkocean/domain/linkmetadata/service/dto/GetLinkMetadataResult.java
+++ b/src/main/java/com/meoguri/linkocean/domain/linkmetadata/service/dto/GetLinkMetadataResult.java
@@ -1,11 +1,11 @@
-package com.meoguri.linkocean.infrastructure.jsoup;
+package com.meoguri.linkocean.domain.linkmetadata.service.dto;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor
-public final class SearchLinkMetadataResult {
+public final class GetLinkMetadataResult {
 
 	private final String title;
 	private final String image;

--- a/src/main/java/com/meoguri/linkocean/infrastructure/jsoup/JsoupGetLinkMetadataService.java
+++ b/src/main/java/com/meoguri/linkocean/infrastructure/jsoup/JsoupGetLinkMetadataService.java
@@ -7,8 +7,11 @@ import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 import org.springframework.stereotype.Service;
 
+import com.meoguri.linkocean.domain.linkmetadata.service.GetLinkMetadata;
+import com.meoguri.linkocean.domain.linkmetadata.service.dto.GetLinkMetadataResult;
+
 @Service
-public class JsoupLinkMetadataService {
+public class JsoupGetLinkMetadataService implements GetLinkMetadata {
 
 	private static final String CONTENT = "content";
 
@@ -22,14 +25,15 @@ public class JsoupLinkMetadataService {
 	 * @return 조회할 수 있지만 링크 메타데이터가 존재하지 않는 경우. DEFAULT_TITLE, DEFAULT_IMAGE를 반환
 	 * @throws IllegalArgumentException 조회할 수 없는 url
 	 */
-	public SearchLinkMetadataResult search(String url) {
+	@Override
+	public GetLinkMetadataResult getLinkMetadata(String url) {
 		try {
 			Document document = Jsoup.connect(url).get();
 
 			final Element titleElement = document.select("meta[property=og:title]").first();
 			final Element imageElement = document.select("meta[property=og:image]").first();
 
-			return new SearchLinkMetadataResult(getTitle(titleElement), getImage(imageElement));
+			return new GetLinkMetadataResult(getTitle(titleElement), getImage(imageElement));
 		} catch (IOException | IllegalArgumentException e) { /* jsoup으로 조회 할 수 없는 url */
 			throw new IllegalArgumentException("링크 메타데이터가 존재하지 않습니다.");
 		}

--- a/src/main/java/com/meoguri/linkocean/infrastructure/jsoup/JsoupLinkMetadataService.java
+++ b/src/main/java/com/meoguri/linkocean/infrastructure/jsoup/JsoupLinkMetadataService.java
@@ -10,30 +10,42 @@ import org.springframework.stereotype.Service;
 @Service
 public class JsoupLinkMetadataService {
 
+	private static final String CONTENT = "content";
+
 	public static final String DEFAULT_TITLE = "제목 없음";
 	public static final String DEFAULT_IMAGE = "default-image.png";
 
 	/**
 	 * http:// 혹은 https:// 로 시작하는 url 에 대해서
 	 * jsoup 을 활용한 metadata 검색 결과 제공
+	 *
+	 * @return 조회할 수 있지만 링크 메타데이터가 존재하지 않는 경우. DEFAULT_TITLE, DEFAULT_IMAGE를 반환
+	 * @throws IllegalArgumentException 조회할 수 없는 url
 	 */
 	public SearchLinkMetadataResult search(String url) {
-		String title = DEFAULT_TITLE;
-		String image = DEFAULT_IMAGE;
-
 		try {
 			Document document = Jsoup.connect(url).get();
 
 			final Element titleElement = document.select("meta[property=og:title]").first();
 			final Element imageElement = document.select("meta[property=og:image]").first();
 
-			title = titleElement == null ? DEFAULT_TITLE : titleElement.attr("content");
-			image = imageElement == null ? DEFAULT_IMAGE : imageElement.attr("content");
-
-			return new SearchLinkMetadataResult(title, image);
-		} catch (IOException | IllegalArgumentException e) {
-			// url 이 올바르지 않은 경우 기본 값으로 결과 반환
-			return new SearchLinkMetadataResult(title, image);
+			return new SearchLinkMetadataResult(getTitle(titleElement), getImage(imageElement));
+		} catch (IOException | IllegalArgumentException e) { /* jsoup으로 조회 할 수 없는 url */
+			throw new IllegalArgumentException("링크 메타데이터가 존재하지 않습니다.");
 		}
+	}
+
+	private String getTitle(final Element titleElement) {
+		if (titleElement == null) {
+			return DEFAULT_TITLE;
+		}
+		return titleElement.attr(CONTENT).isEmpty() ? DEFAULT_TITLE : titleElement.attr(CONTENT);
+	}
+
+	private String getImage(final Element imageElement) {
+		if (imageElement == null) {
+			return DEFAULT_IMAGE;
+		}
+		return imageElement.attr(CONTENT).isEmpty() ? DEFAULT_IMAGE : imageElement.attr(CONTENT);
 	}
 }

--- a/src/test/java/com/meoguri/linkocean/DependencyRuleTest.java
+++ b/src/test/java/com/meoguri/linkocean/DependencyRuleTest.java
@@ -3,6 +3,7 @@ package com.meoguri.linkocean;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.*;
 import static com.tngtech.archunit.library.Architectures.*;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.stereotype.Controller;
 import org.springframework.stereotype.Service;
@@ -34,6 +35,12 @@ class DependencyRuleTest {
 			.check(importPackages);
 	}
 
+	/**
+	 * 레이어 아키텍처의 한계 중 하나가 도메인이 인프라(영속성) 레이어에 의존하게 되는 것입니다.
+	 * 이런 문제는 DIP를 활용하면 해결할 수 있는 부분도 있습니다. LinkMetadata 도메인에서가 딱 그런 경우 같습니다.
+	 * 그래서 해당 제약 조건은 없어져도 될 것 같습니다!
+	 */
+	@Disabled
 	@Test
 	void infrastructure_는_domain_에_접근할_수_없다() {
 		String infrastructurePackage = "com.meoguri.linkocean.infrastructure";

--- a/src/test/java/com/meoguri/linkocean/domain/bookmark/service/BookmarkServiceImplTest.java
+++ b/src/test/java/com/meoguri/linkocean/domain/bookmark/service/BookmarkServiceImplTest.java
@@ -4,7 +4,7 @@ import static com.meoguri.linkocean.domain.bookmark.entity.vo.Category.*;
 import static com.meoguri.linkocean.domain.bookmark.entity.vo.OpenType.*;
 import static com.meoguri.linkocean.domain.bookmark.entity.vo.ReactionType.*;
 import static com.meoguri.linkocean.domain.user.entity.vo.OAuthType.*;
-import static com.meoguri.linkocean.infrastructure.jsoup.JsoupLinkMetadataService.*;
+import static com.meoguri.linkocean.infrastructure.jsoup.JsoupGetLinkMetadataService.*;
 import static com.meoguri.linkocean.test.support.common.Assertions.*;
 import static java.util.Collections.*;
 import static org.assertj.core.api.Assertions.*;

--- a/src/test/java/com/meoguri/linkocean/domain/linkmetadata/service/LinkMetadataServiceImplTest.java
+++ b/src/test/java/com/meoguri/linkocean/domain/linkmetadata/service/LinkMetadataServiceImplTest.java
@@ -1,6 +1,6 @@
 package com.meoguri.linkocean.domain.linkmetadata.service;
 
-import static com.meoguri.linkocean.infrastructure.jsoup.JsoupLinkMetadataService.*;
+import static com.meoguri.linkocean.infrastructure.jsoup.JsoupGetLinkMetadataService.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
 
@@ -13,8 +13,8 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 
-import com.meoguri.linkocean.infrastructure.jsoup.JsoupLinkMetadataService;
-import com.meoguri.linkocean.infrastructure.jsoup.SearchLinkMetadataResult;
+import com.meoguri.linkocean.domain.linkmetadata.service.dto.GetLinkMetadataResult;
+import com.meoguri.linkocean.infrastructure.jsoup.JsoupGetLinkMetadataService;
 import com.meoguri.linkocean.test.support.domain.service.BaseServiceTest;
 
 class LinkMetadataServiceImplTest extends BaseServiceTest {
@@ -23,15 +23,15 @@ class LinkMetadataServiceImplTest extends BaseServiceTest {
 	private LinkMetadataService linkMetadataService;
 
 	@MockBean
-	private JsoupLinkMetadataService jsoupLinkMetadataService;
+	private JsoupGetLinkMetadataService jsoupGetLinkMetadataService;
 
 	@BeforeEach
 	void setUp() {
-		given(jsoupLinkMetadataService.search(anyString()))
-			.willReturn(new SearchLinkMetadataResult(DEFAULT_TITLE, DEFAULT_IMAGE));
+		given(jsoupGetLinkMetadataService.getLinkMetadata(anyString()))
+			.willReturn(new GetLinkMetadataResult(DEFAULT_TITLE, DEFAULT_IMAGE));
 
-		given(jsoupLinkMetadataService.search("https://www.naver.com"))
-			.willReturn(new SearchLinkMetadataResult("네이버", "naver.png"));
+		given(jsoupGetLinkMetadataService.getLinkMetadata("https://www.naver.com"))
+			.willReturn(new GetLinkMetadataResult("네이버", "naver.png"));
 	}
 
 	@Test
@@ -63,8 +63,8 @@ class LinkMetadataServiceImplTest extends BaseServiceTest {
 	void 링크_제목_얻기_성공_유효하지_않은_url() {
 		//given
 		final String invalidUrl = "https://www.invalid.com";
-		given(jsoupLinkMetadataService.search(invalidUrl))
-			.willReturn(new SearchLinkMetadataResult(DEFAULT_TITLE, DEFAULT_IMAGE));
+		given(jsoupGetLinkMetadataService.getLinkMetadata(invalidUrl))
+			.willReturn(new GetLinkMetadataResult(DEFAULT_TITLE, DEFAULT_IMAGE));
 
 		//when
 		final String title = linkMetadataService.obtainTitle(invalidUrl);
@@ -118,12 +118,12 @@ class LinkMetadataServiceImplTest extends BaseServiceTest {
 	}
 
 	private void 네이버_링크_메타데이터_업데이트됨() {
-		final SearchLinkMetadataResult updatedResult = new SearchLinkMetadataResult("네이버짱", "naver-zzang.png");
+		final GetLinkMetadataResult updatedResult = new GetLinkMetadataResult("네이버짱", "naver-zzang.png");
 
-		given(jsoupLinkMetadataService.search("www.naver1.com")).willReturn(updatedResult);
-		given(jsoupLinkMetadataService.search("www.naver2.com")).willReturn(updatedResult);
-		given(jsoupLinkMetadataService.search("www.naver3.com")).willReturn(updatedResult);
-		given(jsoupLinkMetadataService.search("www.naver4.com")).willReturn(updatedResult);
-		given(jsoupLinkMetadataService.search("www.naver5.com")).willReturn(updatedResult);
+		given(jsoupGetLinkMetadataService.getLinkMetadata("www.naver1.com")).willReturn(updatedResult);
+		given(jsoupGetLinkMetadataService.getLinkMetadata("www.naver2.com")).willReturn(updatedResult);
+		given(jsoupGetLinkMetadataService.getLinkMetadata("www.naver3.com")).willReturn(updatedResult);
+		given(jsoupGetLinkMetadataService.getLinkMetadata("www.naver4.com")).willReturn(updatedResult);
+		given(jsoupGetLinkMetadataService.getLinkMetadata("www.naver5.com")).willReturn(updatedResult);
 	}
 }

--- a/src/test/java/com/meoguri/linkocean/infrastructure/jsoup/JsoupGetLinkMetadataServiceTest.java
+++ b/src/test/java/com/meoguri/linkocean/infrastructure/jsoup/JsoupGetLinkMetadataServiceTest.java
@@ -6,9 +6,11 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
-class JsoupLinkMetadataServiceTest {
+import com.meoguri.linkocean.domain.linkmetadata.service.dto.GetLinkMetadataResult;
 
-	JsoupLinkMetadataService service = new JsoupLinkMetadataService();
+class JsoupGetLinkMetadataServiceTest {
+
+	JsoupGetLinkMetadataService service = new JsoupGetLinkMetadataService();
 
 	@ParameterizedTest
 	@CsvSource(value = {
@@ -17,7 +19,7 @@ class JsoupLinkMetadataServiceTest {
 	})
 	void 링크_메타데이터_검색_성공(final String link, final String expectedTitle) {
 		//when
-		final SearchLinkMetadataResult result = service.search(link);
+		final GetLinkMetadataResult result = service.getLinkMetadata(link);
 
 		//then
 		assertThat(result.getTitle()).isEqualTo(expectedTitle);
@@ -32,7 +34,7 @@ class JsoupLinkMetadataServiceTest {
 	void 링크_메타데이터_검색_실패(final String invalidLink) {
 		//when then
 		assertThatIllegalArgumentException()
-			.isThrownBy(() -> service.search(invalidLink));
+			.isThrownBy(() -> service.getLinkMetadata(invalidLink));
 	}
 
 }

--- a/src/test/java/com/meoguri/linkocean/infrastructure/jsoup/JsoupLinkMetadataServiceTest.java
+++ b/src/test/java/com/meoguri/linkocean/infrastructure/jsoup/JsoupLinkMetadataServiceTest.java
@@ -1,6 +1,5 @@
 package com.meoguri.linkocean.infrastructure.jsoup;
 
-import static com.meoguri.linkocean.infrastructure.jsoup.JsoupLinkMetadataService.*;
 import static org.assertj.core.api.Assertions.*;
 
 import org.junit.jupiter.params.ParameterizedTest;
@@ -30,13 +29,10 @@ class JsoupLinkMetadataServiceTest {
 		"invalid link",
 		"http://localhost:8080"
 	})
-	void 링크가_잘못된_경우_검색시_기본값_반환(final String invalidLink) {
-		//when
-		final SearchLinkMetadataResult result = service.search(invalidLink);
-
-		//then
-		assertThat(result.getTitle()).isEqualTo(DEFAULT_TITLE);
-		assertThat(result.getImage()).isEqualTo(DEFAULT_IMAGE);
+	void 링크_메타데이터_검색_실패(final String invalidLink) {
+		//when then
+		assertThatIllegalArgumentException()
+			.isThrownBy(() -> service.search(invalidLink));
 	}
 
 }


### PR DESCRIPTION
<!-- PR 제목 양식 예시: [LO-N] 회원 기능 도메인 -->

## 🛠️ 작업 내용
- 링크 메타데이터 정책 변경

## 🗨️ 기타
<!-- PR 포인트 혹은 궁금한 점 등등 적어주시면 됩니다. 없으시면 지워주세요 -->
- 링크 메타데이터를 조회한 url이 유효하지 않은 경우(Jsoup으로 해당 페이지를 조회하지 못하는 경우) db에 저장하지 않는걸로 정책을 변경했습니다. 
- DIP를 적용해 Jsop이 linkmetadata에 의존하게 변경했습니다. (도메인이 JPA에 의존하는 문제는 JPA라는 기술이 자바 표준이기에 합당한 의존이지만, 도메인이 Jsoup에 의존하는 문제는 Jsoup이라는 기술이 JPA 처럼 표준 기술은 아니기 때문에 DIP를 적용하는게 더 좋다고 판단했습니다.)
<img width="1085" alt="스크린샷 2022-09-02 오후 2 56 06" src="https://user-images.githubusercontent.com/29492667/188068552-69d0ec8b-571a-41ec-8458-a12ce0cbf794.png">

<img width="1059" alt="스크린샷 2022-09-02 오후 2 56 16" src="https://user-images.githubusercontent.com/29492667/188068559-0f8b5d8c-c340-40f9-80e9-ed16cd5cf12d.png">


<hr/>

- s3는 어떻게 처리할지 고민이네요. 🤔 

## 😎 리뷰어
@ndy2 , @jk05018 , @NewEgoDoc, @hyuk0309
