### PR TITLE
[LO-211] 북마크 상세 조회 버그 해결

### DIFF
--- a/src/test/java/com/meoguri/linkocean/controller/bookmark/BookmarkControllerTest.java
+++ b/src/test/java/com/meoguri/linkocean/controller/bookmark/BookmarkControllerTest.java
@@ -44,12 +44,13 @@ class BookmarkControllerTest extends BaseControllerTest {
 			new RegisterBookmarkRequest(링크_메타데이터_얻기("http://www.naver.com"), title, memo, category, openType, null);
 
 		//when
-		mockMvc.perform(post(basePath)
-				.header(AUTHORIZATION, token)
-				.contentType(APPLICATION_JSON)
-				.content(createJson(registerBookmarkRequest)))
+		final ResultActions perform = mockMvc.perform(post(basePath)
+			.header(AUTHORIZATION, token)
+			.contentType(APPLICATION_JSON)
+			.content(createJson(registerBookmarkRequest)));
 
-			//then
+		//then
+		perform
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.id").exists())
 			.andDo(print());
@@ -166,10 +167,12 @@ class BookmarkControllerTest extends BaseControllerTest {
 		@Test
 		void 북마크_상세_조회_성공_제목_메모_카테고리_없음() throws Exception {
 			//when
-			mockMvc.perform(get(basePath + "/" + haniBookmarkId)
-					.header(AUTHORIZATION, token)
-					.contentType(APPLICATION_JSON))
-				//then
+			final ResultActions perform = mockMvc.perform(get(basePath + "/" + haniBookmarkId)
+				.header(AUTHORIZATION, token)
+				.contentType(APPLICATION_JSON));
+
+			//then
+			perform
 				.andExpect(status().isOk())
 				.andExpectAll(
 					jsonPath("$.bookmarkId").value(haniBookmarkId),
@@ -197,7 +200,7 @@ class BookmarkControllerTest extends BaseControllerTest {
 		void 북마크_상세_조회_성공_다른_사람_북마크() throws Exception {
 			//given
 			유저_등록_로그인("crush@gmail.com", GOOGLE);
-			long crushProfileId = 프로필_등록("crush", List.of("정치", "인문", "사회"));
+			프로필_등록("crush", List.of("정치", "인문", "사회"));
 
 			//when
 			final ResultActions perform = mockMvc.perform(get(basePath + "/" + haniBookmarkId)
@@ -227,10 +230,12 @@ class BookmarkControllerTest extends BaseControllerTest {
 		@Test
 		void 내_북마크_목록_조회_Api_성공_필터링_조건_없이_조회() throws Exception {
 			//when
-			mockMvc.perform(get(basePath + "/me")
-					.header(AUTHORIZATION, token)
-					.accept(APPLICATION_JSON))
-				//then
+			final ResultActions perform = mockMvc.perform(get(basePath + "/me")
+				.header(AUTHORIZATION, token)
+				.accept(APPLICATION_JSON));
+
+			//then
+			perform
 				.andExpect(status().isOk())
 				.andExpectAll(
 					jsonPath("$.totalCount").value(2),
@@ -252,11 +257,13 @@ class BookmarkControllerTest extends BaseControllerTest {
 		@Test
 		void 내_북마크_목록_조회_Api_성공_카테고리_필터링() throws Exception {
 			//when
-			mockMvc.perform(get(basePath + "/me")
-					.param("category", "IT")
-					.header(AUTHORIZATION, token)
-					.accept(APPLICATION_JSON))
-				//then
+			final ResultActions perform = mockMvc.perform(get(basePath + "/me")
+				.param("category", "IT")
+				.header(AUTHORIZATION, token)
+				.accept(APPLICATION_JSON));
+
+			//then
+			perform
 				.andExpect(status().isOk())
 				.andExpectAll(
 					jsonPath("$.totalCount").value(1),
@@ -271,11 +278,13 @@ class BookmarkControllerTest extends BaseControllerTest {
 			북마크_즐겨찾기(bookmarkId1);
 
 			//when
-			mockMvc.perform(get(basePath + "/me")
-					.param("favorite", "true")
-					.header(AUTHORIZATION, token)
-					.accept(APPLICATION_JSON))
-				//then
+			final ResultActions perform = mockMvc.perform(get(basePath + "/me")
+				.param("favorite", "true")
+				.header(AUTHORIZATION, token)
+				.accept(APPLICATION_JSON));
+
+			//then
+			perform
 				.andExpect(status().isOk())
 				.andExpectAll(
 					jsonPath("$.totalCount").value(1),
@@ -287,11 +296,13 @@ class BookmarkControllerTest extends BaseControllerTest {
 		@Test
 		void 내_북마크_목록_조회_Api_성공_태그_필터링() throws Exception {
 			//when
-			mockMvc.perform(get(basePath + "/me")
-					.header(AUTHORIZATION, token)
-					.param("tags", "공부,travel")
-					.accept(APPLICATION_JSON))
-				//then
+			final ResultActions perform = mockMvc.perform(get(basePath + "/me")
+				.header(AUTHORIZATION, token)
+				.param("tags", "공부,travel")
+				.accept(APPLICATION_JSON));
+
+			//then
+			perform
 				.andExpect(status().isOk())
 				.andExpectAll(
 					jsonPath("$.totalCount").value(2)
@@ -301,14 +312,13 @@ class BookmarkControllerTest extends BaseControllerTest {
 
 	@Test
 	void Url_중복확인_Api_성공_새로운_url() throws Exception {
-		//given <- ?!?!?
-		final String locationHeader = "Location";
-
 		//when
-		mockMvc.perform(get(basePath + "?url=https://www.google.com")
-				.header(AUTHORIZATION, token)
-				.accept(APPLICATION_JSON))
-			//then
+		final ResultActions perform = mockMvc.perform(get(basePath + "?url=https://www.google.com")
+			.header(AUTHORIZATION, token)
+			.accept(APPLICATION_JSON));
+
+		//then
+		perform
 			.andExpect(status().isOk())
 			.andExpectAll(
 				jsonPath("$.isDuplicateUrl").value(false)
@@ -322,12 +332,14 @@ class BookmarkControllerTest extends BaseControllerTest {
 		final String expectedLocationHeader = "api/v1/bookmarks/" + bookmarkId;
 
 		//when
-		mockMvc.perform(get(basePath + "?url=https://www.google.com")
-				.header(AUTHORIZATION, token)
-				.accept(APPLICATION_JSON))
-			//then
+		final ResultActions perform = mockMvc.perform(get(basePath + "?url=https://www.google.com")
+			.header(AUTHORIZATION, token)
+			.accept(APPLICATION_JSON));
+
+		//then
+		perform
 			.andExpect(status().isOk())
-			.andExpect(header().string("Location", expectedLocationHeader))
+			.andExpect(header().string(LOCATION, expectedLocationHeader))
 			.andExpect(jsonPath("$.isDuplicateUrl").value(true))
 			.andDo(print());
 	}
@@ -360,10 +372,13 @@ class BookmarkControllerTest extends BaseControllerTest {
 
 		@Test
 		void 다른_유저_북마크_목록_조회_Api_모르는_유저() throws Exception {
-			//when then
-			mockMvc.perform(get(basePath + "/others/{profileId}", otherProfileId)
-					.header(AUTHORIZATION, token)
-					.accept(APPLICATION_JSON))
+			//when
+			final ResultActions perform = mockMvc.perform(get(basePath + "/others/{profileId}", otherProfileId)
+				.header(AUTHORIZATION, token)
+				.accept(APPLICATION_JSON));
+
+			//then
+			perform
 				.andExpect(status().isOk())
 				.andExpectAll(
 					jsonPath("$.totalCount").value(2),
@@ -379,10 +394,13 @@ class BookmarkControllerTest extends BaseControllerTest {
 			//given
 			팔로우(otherProfileId);
 
-			//when then
-			mockMvc.perform(get(basePath + "/others/{profileId}", otherProfileId)
-					.header(AUTHORIZATION, token)
-					.accept(APPLICATION_JSON))
+			//when
+			final ResultActions perform = mockMvc.perform(get(basePath + "/others/{profileId}", otherProfileId)
+				.header(AUTHORIZATION, token)
+				.accept(APPLICATION_JSON));
+
+			//then
+			perform
 				.andExpect(status().isOk())
 				.andExpectAll(
 					jsonPath("$.totalCount").value(3),
@@ -403,11 +421,14 @@ class BookmarkControllerTest extends BaseControllerTest {
 
 			로그인("crush@gmail.com", GOOGLE);
 
-			//when then
-			mockMvc.perform(get(basePath + "/others/{profileId}", otherProfileId)
-					.param("favorite", "true")
-					.header(AUTHORIZATION, token)
-					.accept(APPLICATION_JSON))
+			//when
+			final ResultActions perform = mockMvc.perform(get(basePath + "/others/{profileId}", otherProfileId)
+				.param("favorite", "true")
+				.header(AUTHORIZATION, token)
+				.accept(APPLICATION_JSON));
+
+			//then
+			perform
 				.andExpect(status().isOk())
 				.andExpectAll(
 					jsonPath("$.totalCount").value(1),
@@ -418,11 +439,14 @@ class BookmarkControllerTest extends BaseControllerTest {
 
 		@Test
 		void 다른_유저_북마크_목록_조회_Api_모르는_유저_카테고리_필터링() throws Exception {
-			//when then
-			mockMvc.perform(get(basePath + "/others/{profileId}", otherProfileId)
-					.param("category", "IT")
-					.header(AUTHORIZATION, token)
-					.accept(APPLICATION_JSON))
+			//when
+			final ResultActions perform = mockMvc.perform(get(basePath + "/others/{profileId}", otherProfileId)
+				.param("category", "IT")
+				.header(AUTHORIZATION, token)
+				.accept(APPLICATION_JSON));
+
+			//then
+			perform
 				.andExpect(status().isOk())
 				.andExpectAll(
 					jsonPath("$.totalCount").value(1),
@@ -432,11 +456,14 @@ class BookmarkControllerTest extends BaseControllerTest {
 
 		@Test
 		void 다른_유저_북마크_목록_조회_Api_모르는_유저_태그_두개로_필터링() throws Exception {
-			//when then
-			mockMvc.perform(get(basePath + "/others/{profileId}", otherProfileId)
-					.param("tags", "머구리", "공부")
-					.header(AUTHORIZATION, token)
-					.accept(APPLICATION_JSON))
+			//when
+			final ResultActions perform = mockMvc.perform(get(basePath + "/others/{profileId}", otherProfileId)
+				.param("tags", "머구리", "공부")
+				.header(AUTHORIZATION, token)
+				.accept(APPLICATION_JSON));
+
+			//then
+			perform
 				.andExpect(status().isOk())
 				.andExpectAll(
 					jsonPath("$.totalCount").value(2),
@@ -448,11 +475,14 @@ class BookmarkControllerTest extends BaseControllerTest {
 
 		@Test
 		void 다른_유저_북마크_목록_조회_Api_모르는_유저_제목으로_필터링() throws Exception {
-			//when then
-			mockMvc.perform(get(basePath + "/others/{profileId}", otherProfileId)
-					.param("searchTitle", "1")
-					.header(AUTHORIZATION, token)
-					.accept(APPLICATION_JSON))
+			//when
+			final ResultActions perform = mockMvc.perform(get(basePath + "/others/{profileId}", otherProfileId)
+				.param("searchTitle", "1")
+				.header(AUTHORIZATION, token)
+				.accept(APPLICATION_JSON));
+
+			//then
+			perform
 				.andExpect(status().isOk())
 				.andExpectAll(
 					jsonPath("$.totalCount").value(1),
@@ -465,11 +495,14 @@ class BookmarkControllerTest extends BaseControllerTest {
 			//given
 			북마크_좋아요(bookmarkId1);
 
-			//when then
-			mockMvc.perform(get(basePath + "/others/{profileId}", otherProfileId)
-					.param("order", "like")
-					.header(AUTHORIZATION, token)
-					.accept(APPLICATION_JSON))
+			//when
+			final ResultActions perform = mockMvc.perform(get(basePath + "/others/{profileId}", otherProfileId)
+				.param("order", "like")
+				.header(AUTHORIZATION, token)
+				.accept(APPLICATION_JSON));
+
+			//then
+			perform
 				.andExpect(status().isOk())
 				.andExpectAll(
 					jsonPath("$.totalCount").value(2),
@@ -526,10 +559,12 @@ class BookmarkControllerTest extends BaseControllerTest {
 		@Test
 		void 피드_북마크_조회_Api_성공() throws Exception {
 			//when
-			mockMvc.perform(get(basePath + "/feed")
-					.header(AUTHORIZATION, token)
-					.accept(APPLICATION_JSON))
-				//then
+			final ResultActions perform = mockMvc.perform(get(basePath + "/feed")
+				.header(AUTHORIZATION, token)
+				.accept(APPLICATION_JSON));
+
+			//then
+			perform
 				.andExpect(status().isOk())
 				.andExpectAll(
 					jsonPath("$.totalCount").value(6),
@@ -546,11 +581,13 @@ class BookmarkControllerTest extends BaseControllerTest {
 		@Test
 		void 피드_북마크_조회_Api_성공_팔로워_글_필터링() throws Exception {
 			//when
-			mockMvc.perform(get(basePath + "/feed")
-					.param("follow", "true")
-					.header(AUTHORIZATION, token)
-					.accept(APPLICATION_JSON))
-				//then
+			final ResultActions perform = mockMvc.perform(get(basePath + "/feed")
+				.param("follow", "true")
+				.header(AUTHORIZATION, token)
+				.accept(APPLICATION_JSON));
+
+			//then
+			perform
 				.andExpect(status().isOk())
 				.andExpectAll(
 					jsonPath("$.totalCount").value(2),
@@ -567,11 +604,13 @@ class BookmarkControllerTest extends BaseControllerTest {
 			북마크_즐겨찾기(bookmarkId10);
 
 			//when
-			mockMvc.perform(get(basePath + "/feed")
-					.param("favorite", "true")
-					.header(AUTHORIZATION, token)
-					.accept(APPLICATION_JSON))
-				//then
+			final ResultActions perform = mockMvc.perform(get(basePath + "/feed")
+				.param("favorite", "true")
+				.header(AUTHORIZATION, token)
+				.accept(APPLICATION_JSON));
+
+			//then
+			perform
 				.andExpect(status().isOk())
 				.andExpectAll(
 					jsonPath("$.totalCount").value(1),

--- a/src/test/java/com/meoguri/linkocean/controller/bookmark/BookmarkControllerTest.java
+++ b/src/test/java/com/meoguri/linkocean/controller/bookmark/BookmarkControllerTest.java
@@ -300,7 +300,7 @@ class BookmarkControllerTest extends BaseControllerTest {
 	}
 
 	@Test
-	void Url_중복확인_성공_새로운_url() throws Exception {
+	void Url_중복확인_Api_성공_새로운_url() throws Exception {
 		//given <- ?!?!?
 		final String locationHeader = "Location";
 
@@ -316,7 +316,7 @@ class BookmarkControllerTest extends BaseControllerTest {
 	}
 
 	@Test
-	void Url_중복확인_성공_이미있는_url() throws Exception {
+	void Url_중복확인_Api_성공_이미있는_url() throws Exception {
 		//given
 		final long bookmarkId = 북마크_등록(링크_메타데이터_얻기("https://www.google.com"), "title1", "IT", List.of("공부"), "all");
 		final String expectedLocationHeader = "api/v1/bookmarks/" + bookmarkId;
@@ -359,7 +359,7 @@ class BookmarkControllerTest extends BaseControllerTest {
 		}
 
 		@Test
-		void 모르는_유저_북마크_목록_조회() throws Exception {
+		void 다른_유저_북마크_목록_조회_Api_모르는_유저() throws Exception {
 			//when then
 			mockMvc.perform(get(basePath + "/others/{profileId}", otherProfileId)
 					.header(AUTHORIZATION, token)
@@ -375,7 +375,7 @@ class BookmarkControllerTest extends BaseControllerTest {
 		}
 
 		@Test
-		void 팔로우_유저_북마크_목록_조회() throws Exception {
+		void 다른_유저_북마크_목록_조회_Api_팔로우_유저() throws Exception {
 			//given
 			팔로우(otherProfileId);
 
@@ -396,7 +396,7 @@ class BookmarkControllerTest extends BaseControllerTest {
 		}
 
 		@Test
-		void 모르는_유저_북마크_목록_조회_즐겨찾기_필터링() throws Exception {
+		void 다른_유저_북마크_목록_조회_Api_모르는_유저_즐겨찾기_필터링() throws Exception {
 			//given
 			로그인("otherUser@gmail.com", GOOGLE);
 			북마크_즐겨찾기(bookmarkId1);
@@ -417,7 +417,7 @@ class BookmarkControllerTest extends BaseControllerTest {
 		}
 
 		@Test
-		void 모르는_유저_북마크_목록_조회_카테고리_필터링() throws Exception {
+		void 다른_유저_북마크_목록_조회_Api_모르는_유저_카테고리_필터링() throws Exception {
 			//when then
 			mockMvc.perform(get(basePath + "/others/{profileId}", otherProfileId)
 					.param("category", "IT")
@@ -431,7 +431,7 @@ class BookmarkControllerTest extends BaseControllerTest {
 		}
 
 		@Test
-		void 모르는_유저_북마크_목록_조회_태그_두개로_필터링() throws Exception {
+		void 다른_유저_북마크_목록_조회_Api_모르는_유저_태그_두개로_필터링() throws Exception {
 			//when then
 			mockMvc.perform(get(basePath + "/others/{profileId}", otherProfileId)
 					.param("tags", "머구리", "공부")
@@ -447,7 +447,7 @@ class BookmarkControllerTest extends BaseControllerTest {
 		}
 
 		@Test
-		void 모르는_유저_북마크_목록_조회_제목으로_필터링() throws Exception {
+		void 다른_유저_북마크_목록_조회_Api_모르는_유저_제목으로_필터링() throws Exception {
 			//when then
 			mockMvc.perform(get(basePath + "/others/{profileId}", otherProfileId)
 					.param("searchTitle", "1")
@@ -461,7 +461,7 @@ class BookmarkControllerTest extends BaseControllerTest {
 		}
 
 		@Test
-		void 모르는_유저_북마크_목록_조회_좋아요_순으로_정렬() throws Exception {
+		void 다른_유저_북마크_목록_조회_Api_모르는_유저_좋아요_순으로_정렬() throws Exception {
 			//given
 			북마크_좋아요(bookmarkId1);
 
@@ -524,7 +524,7 @@ class BookmarkControllerTest extends BaseControllerTest {
 		}
 
 		@Test
-		void 피드_북마크_조회_성공() throws Exception {
+		void 피드_북마크_조회_Api_성공() throws Exception {
 			//when
 			mockMvc.perform(get(basePath + "/feed")
 					.header(AUTHORIZATION, token)
@@ -544,7 +544,7 @@ class BookmarkControllerTest extends BaseControllerTest {
 		}
 
 		@Test
-		void 피드_북마크_조회_팔로우_여부로_성공() throws Exception {
+		void 피드_북마크_조회_Api_성공_팔로워_글_필터링() throws Exception {
 			//when
 			mockMvc.perform(get(basePath + "/feed")
 					.param("follow", "true")
@@ -560,8 +560,9 @@ class BookmarkControllerTest extends BaseControllerTest {
 				).andDo(print());
 		}
 
+		//질문 : 현재 프론트에서는 피드 페이지 필터링이 없는데, 여긴 있네요?? (그리고 피드 페이지에서 즐겨찾기 필터링이 의미 있을까요?)
 		@Test
-		void 피드_북마크_조회_즐겨찾기_후_조회_성공() throws Exception {
+		void 피드_북마크_조회_Api_성공_즐겨찾기_후_조회() throws Exception {
 			로그인("user2@gmail.com", GOOGLE);
 			북마크_즐겨찾기(bookmarkId10);
 

--- a/src/test/java/com/meoguri/linkocean/controller/bookmark/BookmarkControllerTest.java
+++ b/src/test/java/com/meoguri/linkocean/controller/bookmark/BookmarkControllerTest.java
@@ -24,12 +24,12 @@ class BookmarkControllerTest extends BaseControllerTest {
 
 	private final String basePath = getBaseUrl(BookmarkController.class);
 
-	private long profileId;
+	private long haniProfileId;
 
 	@BeforeEach
 	void setUp() throws Exception {
 		유저_등록_로그인("hani@gmail.com", GOOGLE);
-		profileId = 프로필_등록("hani", List.of("정치", "인문", "사회"));
+		haniProfileId = 프로필_등록("hani", List.of("정치", "인문", "사회"));
 	}
 
 	@Test
@@ -122,7 +122,7 @@ class BookmarkControllerTest extends BaseControllerTest {
 				jsonPath("$.reactionCount.HATE").value(0),
 				jsonPath("$.reaction.LIKE").value(false),
 				jsonPath("$.reaction.HATE").value(false),
-				jsonPath("$.profile.profileId").value(profileId),
+				jsonPath("$.profile.profileId").value(haniProfileId),
 				jsonPath("$.profile.username").value("hani"),
 				jsonPath("$.profile.imageUrl").value(nullValue()),
 				jsonPath("$.profile.isFollow").value(false)
@@ -164,7 +164,7 @@ class BookmarkControllerTest extends BaseControllerTest {
 		}
 
 		@Test
-		void 제목_메모_카테고리_없는_북마크_상세_조회_Api_성공() throws Exception {
+		void 북마크_상세_조회_성공_제목_메모_카테고리_없음() throws Exception {
 			//when
 			mockMvc.perform(get(basePath + "/" + haniBookmarkId)
 					.header(AUTHORIZATION, token)
@@ -186,7 +186,7 @@ class BookmarkControllerTest extends BaseControllerTest {
 					jsonPath("$.reactionCount.HATE").value(0),
 					jsonPath("$.reaction.LIKE").value(false),
 					jsonPath("$.reaction.HATE").value(false),
-					jsonPath("$.profile.profileId").value(profileId),
+					jsonPath("$.profile.profileId").value(haniProfileId),
 					jsonPath("$.profile.username").value("hani"),
 					jsonPath("$.profile.imageUrl").value(nullValue()),
 					jsonPath("$.profile.isFollow").value(false)
@@ -207,13 +207,13 @@ class BookmarkControllerTest extends BaseControllerTest {
 			//then
 			perform
 				.andExpect(status().isOk())
-				.andExpect(jsonPath("$.profile.profileId").value(profileId))
+				.andExpect(jsonPath("$.profile.profileId").value(haniProfileId))
 				.andDo(print());
 		}
 	}
 
 	@Nested
-	class 내_북마크_목록_조회_테스트 {
+	class 내_북마크_목록_조회 {
 
 		private long bookmarkId1;
 		private long bookmarkId2;
@@ -333,7 +333,7 @@ class BookmarkControllerTest extends BaseControllerTest {
 	}
 
 	@Nested
-	class 다른_유저_북마크_목록_조회_테스트 {
+	class 다른_유저_북마크_목록_조회 {
 
 		private long bookmarkId1;
 		private long bookmarkId2;

--- a/src/test/java/com/meoguri/linkocean/domain/bookmark/service/BookmarkServiceImplTest.java
+++ b/src/test/java/com/meoguri/linkocean/domain/bookmark/service/BookmarkServiceImplTest.java
@@ -286,6 +286,18 @@ class BookmarkServiceImplTest extends BaseServiceTest {
 				.isThrownBy(() -> 북마크_상세_조회(profileId, invalidBookmarkId));
 		}
 
+		@Test
+		void 북마크_상세_조회_성공_다른_사람_북마크() {
+			//given
+			final long crushProfileId = 사용자_프로필_동시_등록("crush@gmail.com", GOOGLE, "crush", IT);
+
+			//when
+			final GetDetailedBookmarkResult result = bookmarkService.getDetailedBookmark(crushProfileId, bookmarkId);
+
+			//then
+			assertThat(result.getProfile().getProfileId()).isEqualTo(profileId);
+		}
+
 	}
 
 	@Nested


### PR DESCRIPTION
<!-- PR 제목 양식 예시: [LO-N] 회원 기능 도메인 -->

## 🛠️ 작업 내용
- 북마크 상세 조회 버그 해결

## 🗨️ 기타
<!-- PR 포인트 혹은 궁금한 점 등등 적어주시면 됩니다. 없으시면 지워주세요 -->
- 다른 사람 북마크 상세 조회시 프로필 응답값이 제대로 내려오지 않는 이슈가 있었어요. ([참조](https://www.notion.so/backend-devcourse/b4824b0a86c04ca392b64fa6c81a7ca3))
- 관련된 테스트가 없어서 테스트 작성해서 이상 없는거 확인 했습니다. (따로 수정한건 없습니다. 리팩토링하면서 잡힌 것 같아요..)
- 북마크 컨트롤러 테스트 리팩토링 했습니다. 
  - 테스트 네이밍 통일
  - when, then 영역 명확하게 분리 

<hr/>

- controller test 메서드 네이밍이 전반적으로 통일된 것 같지 않네요 ㅎㅎ (api가 붙은 테스트도 있고 없는 테스트도 있네요) 천천히 고치겠습니다.
- controller test 에서도 when, then 영역을 분리하면 좋겠다는 생각이 들어서 명확하게 분리해 봤습니다. 괜찮으면 컨벤션에 추가해도 좋을 것 같아요. ✋ 

## 😎 리뷰어
@ndy2 , @jk05018 , @NewEgoDoc, @hyuk0309
