### PR TITLE
[LO-212] 링크 메타데이터 동기화 버그 해결

### DIFF
--- a/src/main/java/com/meoguri/linkocean/domain/linkmetadata/service/LinkMetadataServiceImpl.java
+++ b/src/main/java/com/meoguri/linkocean/domain/linkmetadata/service/LinkMetadataServiceImpl.java
@@ -47,11 +47,17 @@ public class LinkMetadataServiceImpl implements LinkMetadataService {
 	public Pageable synchronizeDataAndReturnNextPageable(final Pageable pageable) {
 		final Slice<LinkMetadata> slice = linkMetadataRepository.findBy(pageable);
 
-		slice.forEach(link -> {
-			final GetLinkMetadataResult result = getLinkMetadata.getLinkMetadata(Link.toString(link.getLink()));
-			link.update(result.getTitle(), result.getImage());
-		});
+		slice.forEach(this::synchronizeLinkMetadata);
 
 		return slice.hasNext() ? slice.nextPageable() : null;
+	}
+
+	private void synchronizeLinkMetadata(final LinkMetadata link) {
+		try {
+			final GetLinkMetadataResult result = getLinkMetadata.getLinkMetadata(Link.toString(link.getLink()));
+			link.update(result.getTitle(), result.getImage());
+		} catch (IllegalArgumentException e) {
+			linkMetadataRepository.delete(link);
+		}
 	}
 }

--- a/src/test/java/com/meoguri/linkocean/domain/linkmetadata/service/LinkMetadataServiceImplTest.java
+++ b/src/test/java/com/meoguri/linkocean/domain/linkmetadata/service/LinkMetadataServiceImplTest.java
@@ -2,6 +2,7 @@ package com.meoguri.linkocean.domain.linkmetadata.service;
 
 import static com.meoguri.linkocean.infrastructure.jsoup.JsoupGetLinkMetadataService.*;
 import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
 
 import java.util.List;
@@ -124,5 +125,46 @@ class LinkMetadataServiceImplTest extends BaseServiceTest {
 		given(getLinkMetadata.getLinkMetadata("www.naver3.com")).willReturn(updatedResult);
 		given(getLinkMetadata.getLinkMetadata("www.naver4.com")).willReturn(updatedResult);
 		given(getLinkMetadata.getLinkMetadata("www.naver5.com")).willReturn(updatedResult);
+	}
+
+	@Test
+	void 링크_메타데이터_동기화_성공_유효하지_않은_url_존재() {
+		//given
+		final String crushUrl = "https://crush.com";
+
+		final String originTitle1 = 링크_제목_얻기("https://www.naver.com");
+		final String originTitle2 = 링크_제목_얻기(crushUrl);
+		final String originTitle3 = 링크_제목_얻기("https://haha.com");
+
+		assertAll(
+			() -> assertThat(originTitle1).isEqualTo("네이버"),
+			() -> assertThat(originTitle2).isEqualTo(DEFAULT_TITLE),
+			() -> assertThat(originTitle3).isEqualTo(DEFAULT_TITLE)
+		);
+
+		링크_메타데이터_업데이트("https://www.naver.com", "네이버 채용", "naver-recruite.png");
+		링크_메타데이터_없어짐(crushUrl);
+		링크_메타데이터_업데이트("https://haha.com", "하하", "haha.png");
+
+		//when
+		linkMetadataService.synchronizeDataAndReturnNextPageable(createPageable());
+
+		em.flush();
+		em.clear();
+
+		//then
+		assertAll(
+			() -> assertThat(링크_제목_얻기("https://www.naver.com")).isEqualTo("네이버 채용"),
+			() -> assertThat(링크_제목_얻기(crushUrl)).isNull(),
+			() -> assertThat(링크_제목_얻기("https://haha.com")).isEqualTo("하하")
+		);
+	}
+
+	private void 링크_메타데이터_업데이트(String url, String title, String image) {
+		given(getLinkMetadata.getLinkMetadata(url)).willReturn(new GetLinkMetadataResult(title, image));
+	}
+
+	private void 링크_메타데이터_없어짐(String url) {
+		given(getLinkMetadata.getLinkMetadata(url)).willThrow(new IllegalArgumentException());
 	}
 }


### PR DESCRIPTION
<!-- PR 제목 양식 예시: [LO-N] 회원 기능 도메인 -->

## 🛠️ 작업 내용
- 링크 메타데이터 동기화 버그 해결

## 🗨️ 기타
<!-- PR 포인트 혹은 궁금한 점 등등 적어주시면 됩니다. 없으시면 지워주세요 -->
-  링크 메타데이터 동기화 시점에 url이 유효하지 않게 바뀌면 (해당 페이지가 사라지면) 예외가 발생해 업데이트가 안되는 이슈 해결
- 관련 테스트 작성

## 😎 리뷰어
@ndy2 , @jk05018 , @NewEgoDoc, @hyuk0309
