### PR TITLE
[LO-215] 컨트롤러 테스트 @Transactional 제거 & 컨밴션에 맞게 리팩토링

### DIFF
--- a/src/test/java/com/meoguri/linkocean/controller/bookmark/CategoryControllerTest.java
+++ b/src/test/java/com/meoguri/linkocean/controller/bookmark/CategoryControllerTest.java
@@ -9,6 +9,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.ResultActions;
 
 import com.meoguri.linkocean.test.support.controller.BaseControllerTest;
 
@@ -22,10 +23,12 @@ class CategoryControllerTest extends BaseControllerTest {
 		유저_등록_로그인("hello@gmail.com", GOOGLE);
 
 		//when
-		mockMvc.perform(get(basePath)
-				.contentType(MediaType.APPLICATION_JSON)
-				.header(AUTHORIZATION, token))
-			//then
+		final ResultActions perform = mockMvc.perform(get(basePath)
+			.contentType(MediaType.APPLICATION_JSON)
+			.header(AUTHORIZATION, token));
+
+		//then
+		perform
 			.andExpect(status().isOk())
 			.andExpectAll(
 				jsonPath("$.categories").isArray(),

--- a/src/test/java/com/meoguri/linkocean/controller/bookmark/ReactionControllerTest.java
+++ b/src/test/java/com/meoguri/linkocean/controller/bookmark/ReactionControllerTest.java
@@ -32,12 +32,11 @@ class ReactionControllerTest extends BaseControllerTest {
 	}
 
 	@Test
-	void 리액션_좋아요() throws Exception {
+	void 리액션_요청_Api_성공_좋아요() throws Exception {
 		//when
 		mockMvc.perform(post(basePath + "/{bookmarkId}/reactions/{reactionType}", bookmarkId, "like")
 				.header(AUTHORIZATION, token)
 				.contentType(MediaType.APPLICATION_JSON))
-
 			//then
 			.andExpect(status().isOk())
 			.andDo(print());
@@ -58,9 +57,11 @@ class ReactionControllerTest extends BaseControllerTest {
 	}
 
 	@Test
-	void 리액션_좋아요_싫어요() throws Exception {
-		//when
+	void 리액션_요청_Api_성공_좋아요_후_싫어요() throws Exception {
+		//given
 		북마크_좋아요(bookmarkId);
+
+		//when
 		북마크_싫어요(bookmarkId);
 
 		//then
@@ -79,9 +80,11 @@ class ReactionControllerTest extends BaseControllerTest {
 	}
 
 	@Test
-	void 리액션_좋아요_좋아요() throws Exception {
-		//when
+	void 리액션_요청_Api_성공_좋아요_후_좋아요() throws Exception {
+		//given
 		북마크_좋아요(bookmarkId);
+
+		//when
 		북마크_좋아요(bookmarkId);
 
 		//then

--- a/src/test/java/com/meoguri/linkocean/controller/linkmetadata/LinkMetadataControllerTest.java
+++ b/src/test/java/com/meoguri/linkocean/controller/linkmetadata/LinkMetadataControllerTest.java
@@ -11,6 +11,7 @@ import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.ResultActions;
 
 import com.meoguri.linkocean.test.support.controller.BaseControllerTest;
 
@@ -28,13 +29,15 @@ class LinkMetadataControllerTest extends BaseControllerTest {
 		final Map<String, String> request = Map.of("url", link);
 
 		//when
-		mockMvc.perform(post(basePath + "/obtain")
-				.header(AUTHORIZATION, token)
-				.contentType(MediaType.APPLICATION_JSON)
-				.content(createJson(request)))
+		final ResultActions perform = mockMvc.perform(post(basePath + "/obtain")
+			.header(AUTHORIZATION, token)
+			.contentType(MediaType.APPLICATION_JSON)
+			.content(createJson(request)));
+
+		//then
+		perform
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.title").exists())
 			.andDo(print());
 	}
-
 }

--- a/src/test/java/com/meoguri/linkocean/controller/notification/NotificationControllerTest.java
+++ b/src/test/java/com/meoguri/linkocean/controller/notification/NotificationControllerTest.java
@@ -14,6 +14,7 @@ import java.util.Map;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.test.web.servlet.ResultActions;
 
 import com.meoguri.linkocean.test.support.controller.BaseControllerTest;
 
@@ -37,7 +38,7 @@ class NotificationControllerTest extends BaseControllerTest {
 	}
 
 	@Test
-	void 공유_알림_생성하고_조회_성공() throws Exception {
+	void 공유_알림_생성_Api_성공() throws Exception {
 		//given
 		로그인("sender@gmail.com", GOOGLE);
 		final Map<String, Long> request = Map.of(
@@ -80,7 +81,7 @@ class NotificationControllerTest extends BaseControllerTest {
 	}
 
 	@Test
-	void 대상이_나를_팔로우_중이_아니라면_공유_알림_추가_실패() throws Exception {
+	void 공유_알림_생성_Api_실패_대상이_나를_팔로우_중이_아님() throws Exception {
 		//given
 		로그인("target@gmail.com", GOOGLE);
 		final Map<String, Object> request = Map.of(
@@ -88,27 +89,34 @@ class NotificationControllerTest extends BaseControllerTest {
 		);
 
 		//when
-		mockMvc.perform(post("/api/v1/bookmarks/{bookmarkId}" + "/share", unsharableBookmarkId)
+		final ResultActions perform = mockMvc.perform(
+			post("/api/v1/bookmarks/{bookmarkId}" + "/share", unsharableBookmarkId)
 				.header(AUTHORIZATION, token)
 				.contentType(APPLICATION_JSON)
-				.content(createJson(request)))
-			//then
+				.content(createJson(request)));
+
+		//then
+		perform
 			.andExpect(status().isBadRequest());
 	}
 
 	@Test
-	void 일부_공개글_공유_알림_생성_요청_실패() throws Exception {
+	void 공유_알림_생성_Api_실패_북마크_공개범위_일부_공개() throws Exception {
 		//given
 		로그인("sender@gmail.com", GOOGLE);
 		final Map<String, Object> request = Map.of(
 			"targetId", targetProfileId
 		);
+
 		//when
-		mockMvc.perform(post("/api/v1/bookmarks/{bookmarkId}" + "/share", unsharableBookmarkId)
+		final ResultActions perform = mockMvc.perform(
+			post("/api/v1/bookmarks/{bookmarkId}" + "/share", unsharableBookmarkId)
 				.header(AUTHORIZATION, token)
 				.contentType(APPLICATION_JSON)
-				.content(createJson(request)))
-			//then
+				.content(createJson(request)));
+
+		//then
+		perform
 			.andExpect(status().isBadRequest());
 	}
 }

--- a/src/test/java/com/meoguri/linkocean/controller/profile/FavoriteControllerTest.java
+++ b/src/test/java/com/meoguri/linkocean/controller/profile/FavoriteControllerTest.java
@@ -10,6 +10,7 @@ import java.util.List;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.ResultActions;
 
 import com.meoguri.linkocean.test.support.controller.BaseControllerTest;
 
@@ -19,24 +20,24 @@ class FavoriteControllerTest extends BaseControllerTest {
 
 	@Test
 	void 즐겨찾기_추가_Api_성공() throws Exception {
-
 		//given
 		유저_등록_로그인("haha@gmail.com", NAVER);
 		프로필_등록("haha", List.of("인문", "정치", "사회", "IT"));
 		final long bookmarkId = 북마크_등록(링크_메타데이터_얻기("http://www.naver.com"), "인문", List.of("tag1", "tag2"), "all");
 
 		//when
-		mockMvc.perform(post(basePath + "/{bookmarkId}/favorite", bookmarkId)
-				.header(AUTHORIZATION, token)
-				.contentType(MediaType.APPLICATION_JSON))
+		final ResultActions perform = mockMvc.perform(post(basePath + "/{bookmarkId}/favorite", bookmarkId)
+			.header(AUTHORIZATION, token)
+			.contentType(MediaType.APPLICATION_JSON));
 
-			//then
+		//then
+		perform
 			.andExpect(status().isOk())
 			.andDo(print());
 	}
 
 	@Test
-	void 즐겨찾기_두번_연속_호출_실패() throws Exception {
+	void 즐겨찾기_추가_Api_실패_두번_연속_호출() throws Exception {
 		//given
 		유저_등록_로그인("haha@gmail.com", NAVER);
 		프로필_등록("haha", List.of("인문", "정치", "사회", "IT"));
@@ -44,10 +45,12 @@ class FavoriteControllerTest extends BaseControllerTest {
 		북마크_즐겨찾기(bookmarkId);
 
 		//when
-		mockMvc.perform(post(basePath + "/{bookmarkId}/favorite", bookmarkId)
-				.header(AUTHORIZATION, token)
-				.contentType(MediaType.APPLICATION_JSON))
-			//then
+		final ResultActions perform = mockMvc.perform(post(basePath + "/{bookmarkId}/favorite", bookmarkId)
+			.header(AUTHORIZATION, token)
+			.contentType(MediaType.APPLICATION_JSON));
+
+		//then
+		perform
 			.andExpect(status().isBadRequest())
 			.andDo(print());
 	}

--- a/src/test/java/com/meoguri/linkocean/controller/profile/FollowControllerTest.java
+++ b/src/test/java/com/meoguri/linkocean/controller/profile/FollowControllerTest.java
@@ -11,6 +11,7 @@ import java.util.List;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.test.web.servlet.ResultActions;
 
 import com.meoguri.linkocean.controller.profile.dto.GetDetailedProfileResponse;
 import com.meoguri.linkocean.test.support.controller.BaseControllerTest;
@@ -38,10 +39,10 @@ class FollowControllerTest extends BaseControllerTest {
 				.param("followeeId", String.valueOf(hahaId))
 				.header(AUTHORIZATION, token)
 				.contentType(APPLICATION_JSON))
-
 			//then
 			.andExpect(status().isOk());
 
+		//then
 		final GetDetailedProfileResponse hahaProfile = 프로필_상세_조회(hahaId);
 		final GetDetailedProfileResponse papaProfile = 내_프로필_조회();
 
@@ -53,17 +54,18 @@ class FollowControllerTest extends BaseControllerTest {
 	}
 
 	@Test
-	void 팔로우_두번_연속_실패() throws Exception {
+	void 팔로우_Api_실패_두번_연속_요청() throws Exception {
 		//given
 		팔로우(hahaId);
 
 		//when
-		mockMvc.perform(post(baseUrl + "/follow")
-				.param("followeeId", String.valueOf(hahaId))
-				.header(AUTHORIZATION, token)
-				.contentType(APPLICATION_JSON))
+		final ResultActions perform = mockMvc.perform(post(baseUrl + "/follow")
+			.param("followeeId", String.valueOf(hahaId))
+			.header(AUTHORIZATION, token)
+			.contentType(APPLICATION_JSON));
 
-			//then
+		//then
+		perform
 			.andExpect(status().isBadRequest());
 	}
 
@@ -77,10 +79,10 @@ class FollowControllerTest extends BaseControllerTest {
 				.param("followeeId", String.valueOf(hahaId))
 				.header(AUTHORIZATION, token)
 				.contentType(APPLICATION_JSON))
-
 			//then
 			.andExpect(status().isOk());
 
+		//then
 		final GetDetailedProfileResponse hahaProfile = 프로필_상세_조회(hahaId);
 		final GetDetailedProfileResponse papaProfile = 내_프로필_조회();
 
@@ -92,14 +94,15 @@ class FollowControllerTest extends BaseControllerTest {
 	}
 
 	@Test
-	void 팔로우_안하고_언팔로우_하면_실패() throws Exception {
+	void 언팔로우_Api_실패_팔로우_안하고_언팔로우() throws Exception {
 		//when
-		mockMvc.perform(post(baseUrl + "/unfollow")
-				.param("followeeId", String.valueOf(hahaId))
-				.header(AUTHORIZATION, token)
-				.contentType(APPLICATION_JSON))
+		final ResultActions perform = mockMvc.perform(post(baseUrl + "/unfollow")
+			.param("followeeId", String.valueOf(hahaId))
+			.header(AUTHORIZATION, token)
+			.contentType(APPLICATION_JSON));
 
-			//then
+		//then
+		perform
 			.andExpect(status().isBadRequest());
 	}
 }

--- a/src/test/java/com/meoguri/linkocean/controller/profile/ProfileControllerTest.java
+++ b/src/test/java/com/meoguri/linkocean/controller/profile/ProfileControllerTest.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.web.servlet.ResultActions;
 
 import com.meoguri.linkocean.controller.profile.dto.CreateProfileRequest;
 import com.meoguri.linkocean.controller.profile.dto.GetDetailedProfileResponse;
@@ -35,30 +36,34 @@ class ProfileControllerTest extends BaseControllerTest {
 		final CreateProfileRequest createProfileRequest = new CreateProfileRequest(username, categories);
 
 		//when
-		mockMvc.perform(post(baseUrl)
-				.header(AUTHORIZATION, token)
-				.contentType(APPLICATION_JSON)
-				.content(createJson(createProfileRequest)))
-			//then
+		final ResultActions perform = mockMvc.perform(post(baseUrl)
+			.header(AUTHORIZATION, token)
+			.contentType(APPLICATION_JSON)
+			.content(createJson(createProfileRequest)));
+
+		//then
+		perform
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.id").exists())
 			.andDo(print());
 	}
 
 	@Nested
-	class 내_프로필_조회_테스트 {
+	class 내_프로필_조회 {
 
 		@Test
-		void 내프로필_조회_단순_프로필_정보_조회() throws Exception {
+		void 내_프로필_조회_Api() throws Exception {
 			//given
 			유저_등록_로그인("hani@gmail.com", GOOGLE);
 			프로필_등록("hani", List.of("인문", "정치", "사회"));
 
 			//when
-			mockMvc.perform(get(baseUrl + "/me")
-					.header(AUTHORIZATION, token)
-					.contentType(APPLICATION_JSON))
-				//then
+			final ResultActions perform = mockMvc.perform(get(baseUrl + "/me")
+				.header(AUTHORIZATION, token)
+				.contentType(APPLICATION_JSON));
+
+			//then
+			perform
 				.andExpect(status().isOk())
 				.andExpectAll(
 					jsonPath("$.profileId").exists(),
@@ -75,7 +80,7 @@ class ProfileControllerTest extends BaseControllerTest {
 		}
 
 		@Test
-		void 내프로필_조회_사용자가_작성한_카테고리_조회() throws Exception {
+		void 내_프로필_조회_Api_내가_작성한_카테고리_조회() throws Exception {
 			//given
 			유저_등록_로그인("hani@gmail.com", GOOGLE);
 			프로필_등록("hani", List.of("인문", "정치", "사회", "IT"));
@@ -85,27 +90,21 @@ class ProfileControllerTest extends BaseControllerTest {
 			북마크_등록(링크_메타데이터_얻기("https://github.com"), "IT", null, "private");
 
 			//when
-			mockMvc.perform(get(baseUrl + "/me")
-					.header(AUTHORIZATION, token)
-					.contentType(APPLICATION_JSON))
-				//then
+			final ResultActions perform = mockMvc.perform(get(baseUrl + "/me")
+				.header(AUTHORIZATION, token)
+				.contentType(APPLICATION_JSON));
+
+			//then
+			perform
 				.andExpect(status().isOk())
 				.andExpectAll(
-					jsonPath("$.profileId").exists(),
-					jsonPath("$.imageUrl").isEmpty(),
-					jsonPath("$.favoriteCategories", hasSize(4)),
-					jsonPath("$.username").value("hani"),
-					jsonPath("$.bio").isEmpty(),
-					jsonPath("$.followerCount").value(0),
-					jsonPath("$.followeeCount").value(0),
-					jsonPath("$.tags", hasSize(0)),
 					jsonPath("$.categories", hasSize(3)),
 					jsonPath("$.categories", hasItems("인문", "사회", "IT")))
 				.andDo(print());
 		}
 
 		@Test
-		void 내프로필_조회_사용자가_작성한_카테고리_조회_카테고리가_null_일때() throws Exception {
+		void 내_프로필_조회_Api_내가_작성한_카테고리_조회_카테고리가_없을때() throws Exception {
 			//given
 			유저_등록_로그인("hani@gmail.com", GOOGLE);
 			프로필_등록("hani", List.of("인문", "정치", "사회", "IT"));
@@ -113,29 +112,20 @@ class ProfileControllerTest extends BaseControllerTest {
 			북마크_등록(링크_메타데이터_얻기("http://www.naver.com"), null, null, "private");
 
 			//when
-			mockMvc.perform(get(baseUrl + "/me")
-					.header(AUTHORIZATION, token)
-					.contentType(APPLICATION_JSON))
-				//then
-				.andExpect(status().isOk())
+			final ResultActions perform = mockMvc.perform(get(baseUrl + "/me")
+				.header(AUTHORIZATION, token)
+				.contentType(APPLICATION_JSON));
 
-				.andExpectAll(
-					jsonPath("$.profileId").exists(),
-					jsonPath("$.imageUrl").isEmpty(),
-					jsonPath("$.favoriteCategories", hasSize(4)),
-					jsonPath("$.username").value("hani"),
-					jsonPath("$.bio").isEmpty(),
-					jsonPath("$.followerCount").value(0),
-					jsonPath("$.followeeCount").value(0),
-					jsonPath("$.tags", hasSize(0)),
-					jsonPath("$.categories", hasSize(0))
-				)
+			//then
+			perform
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.categories", hasSize(0)))
 				.andDo(print());
 		}
 	}
 
 	@Test
-	void 프로필_상세_조회_Api_성공() throws Exception {
+	void 다른_사용자_프로필_조회_Api_성공() throws Exception {
 		//given
 		유저_등록_로그인("user1@gmail.com", GOOGLE);
 		final long user1ProfileId = 프로필_등록("user1", List.of("IT"));
@@ -147,10 +137,12 @@ class ProfileControllerTest extends BaseControllerTest {
 		팔로우(user2ProfileId);
 
 		//when
-		mockMvc.perform(get(baseUrl + "/{profileId}", user2ProfileId)
-				.header(AUTHORIZATION, token)
-				.contentType(APPLICATION_JSON))
-			//then
+		final ResultActions perform = mockMvc.perform(get(baseUrl + "/{profileId}", user2ProfileId)
+			.header(AUTHORIZATION, token)
+			.contentType(APPLICATION_JSON));
+
+		//then
+		perform
 			.andExpect(status().isOk())
 			.andExpectAll(
 				jsonPath("$.isFollow").value(true),
@@ -160,7 +152,7 @@ class ProfileControllerTest extends BaseControllerTest {
 	}
 
 	@Test
-	void 내프로필_수정_Api_성공() throws Exception {
+	void 프로필_수정_Api_성공() throws Exception {
 		//given
 		유저_등록_로그인("hani@gmail.com", GOOGLE);
 		프로필_등록("hani", List.of("인문", "정치", "사회", "IT"));
@@ -171,7 +163,7 @@ class ProfileControllerTest extends BaseControllerTest {
 		final MockMultipartFile mockImage = new MockMultipartFile("image", "test.png", "image/png",
 			"image".getBytes());
 
-		// 내 프로필 수정
+		//프로필 수정
 		//when
 		mockMvc.perform(multipart(PUT, URI.create(baseUrl + "/me"))
 				.file(mockImage)
@@ -183,11 +175,10 @@ class ProfileControllerTest extends BaseControllerTest {
 			.andExpect(status().isOk())
 			.andDo(print());
 
-		// 수정된 프로필 조회
-		//when
+		//수정된 프로필 조회
+		//then
 		final GetDetailedProfileResponse myProfile = 내_프로필_조회();
 
-		//then
 		assertThat(myProfile.getUsername()).isEqualTo(updateUsername);
 		assertThat(myProfile.getFavoriteCategories()).containsExactlyInAnyOrder("자기계발", "과학");
 		assertThat(myProfile.getBio()).isEqualTo(bio);
@@ -195,7 +186,7 @@ class ProfileControllerTest extends BaseControllerTest {
 	}
 
 	@Nested
-	class 프로필_목록_조회_시리즈_테스트 {
+	class 프로필_목록_조회 {
 		long user1ProfileId;
 		long user2ProfileId;
 		long user3ProfileId;
@@ -221,12 +212,17 @@ class ProfileControllerTest extends BaseControllerTest {
 		}
 
 		@Test
-		void 유저네임으로_프로필_목록_조회_Api_성공() throws Exception {
+		void 프로필_목록_조회_Api_성공_유저네임으로_필터링_검색() throws Exception {
+			//given
 			로그인("user1@gmail.com", GOOGLE);
 
-			mockMvc.perform(get(baseUrl + "?username=" + "user")
-					.header(AUTHORIZATION, token)
-					.contentType(APPLICATION_JSON))
+			//when
+			final ResultActions perform = mockMvc.perform(get(baseUrl + "?username=" + "user")
+				.header(AUTHORIZATION, token)
+				.contentType(APPLICATION_JSON));
+
+			//then
+			perform
 				.andExpect(status().isOk())
 				.andExpectAll(
 					jsonPath("$.hasNext").value(false),
@@ -242,12 +238,17 @@ class ProfileControllerTest extends BaseControllerTest {
 		}
 
 		@Test
-		void 프로필_목록_조회_Api_유저네임을_빠트리면_실패() throws Exception {
+		void 프로필_목록_조회_Api_실패_유저네임_필터링_조건_없음() throws Exception {
+			//given
 			로그인("user1@gmail.com", GOOGLE);
 
-			mockMvc.perform(get(baseUrl)
-					.header(AUTHORIZATION, token)
-					.contentType(APPLICATION_JSON))
+			//when
+			final ResultActions perform = mockMvc.perform(get(baseUrl)
+				.header(AUTHORIZATION, token)
+				.contentType(APPLICATION_JSON));
+
+			//then
+			perform
 				.andExpect(status().isBadRequest())
 				.andDo(print());
 		}
@@ -260,13 +261,18 @@ class ProfileControllerTest extends BaseControllerTest {
 		user3 의 팔로워 : user2		 user3 의 팔로우 여부    x      x     x
 		 */
 		@Test
-		void 팔로워_조회_Api_성공() throws Exception {
+		void 프로필_목록_조회_Api_성공_자신의_팔로워_조회() throws Exception {
+			//given
 			로그인("user1@gmail.com", GOOGLE);
 
-			// user1 -> user1 의 팔로워 조회
-			mockMvc.perform(get(baseUrl + "/{profileId}/{tab}", user1ProfileId, "follower")
+			//when
+			final ResultActions perform = mockMvc.perform(
+				get(baseUrl + "/{profileId}/{tab}", user1ProfileId, "follower")
 					.header(AUTHORIZATION, token)
-					.contentType(APPLICATION_JSON))
+					.contentType(APPLICATION_JSON));
+
+			//then
+			perform
 				.andExpect(status().isOk())
 				.andExpectAll(
 					jsonPath("$.hasNext").value(false),
@@ -274,11 +280,21 @@ class ProfileControllerTest extends BaseControllerTest {
 					jsonPath("$.profiles[0].profileId").value(user2ProfileId),
 					jsonPath("$.profiles[0].isFollow").value(true)
 				);
+		}
 
-			// user1 -> user2 의 팔로워 조회
-			mockMvc.perform(get(baseUrl + "/{profileId}/{tab}", user2ProfileId, "follower")
+		@Test
+		void 프로필_목록_조회_Api_성공_user1이_user2의_팔로워_조회() throws Exception {
+			//given
+			로그인("user1@gmail.com", GOOGLE);
+
+			//when
+			final ResultActions perform = mockMvc.perform(
+				get(baseUrl + "/{profileId}/{tab}", user2ProfileId, "follower")
 					.header(AUTHORIZATION, token)
-					.contentType(APPLICATION_JSON))
+					.contentType(APPLICATION_JSON));
+
+			//then
+			perform
 				.andExpect(status().isOk())
 				.andExpectAll(
 					jsonPath("$.hasNext").value(false),
@@ -286,11 +302,21 @@ class ProfileControllerTest extends BaseControllerTest {
 					jsonPath("$.profiles[0].profileId").value(user1ProfileId),
 					jsonPath("$.profiles[0].isFollow").value(false)
 				);
+		}
 
-			// user1 -> user3 의 팔로워 조회
-			mockMvc.perform(get(baseUrl + "/{profileId}/{tab}", user3ProfileId, "follower")
+		@Test
+		void 프로필_목록_조회_Api_성공_user1이_user3의_팔로워_조회() throws Exception {
+			//given
+			로그인("user1@gmail.com", GOOGLE);
+
+			//when
+			final ResultActions perform = mockMvc.perform(
+				get(baseUrl + "/{profileId}/{tab}", user3ProfileId, "follower")
 					.header(AUTHORIZATION, token)
-					.contentType(APPLICATION_JSON))
+					.contentType(APPLICATION_JSON));
+
+			//then
+			perform
 				.andExpect(status().isOk())
 				.andExpectAll(
 					jsonPath("$.hasNext").value(false),
@@ -308,24 +334,39 @@ class ProfileControllerTest extends BaseControllerTest {
 		user3 의 팔로이 : x				 user3 의 팔로우 여부    x      x     x
 		 */
 		@Test
-		void 팔로이_조회_Api_성공() throws Exception {
+		void 프로필_목록_조회_Api_성공_자신의_팔로이_조회() throws Exception {
+			//given
 			로그인("user1@gmail.com", GOOGLE);
 
-			// user1 -> user1 의 팔로이 조회
-			mockMvc.perform(get(baseUrl + "/{profileId}/{tab}", user1ProfileId, "followee")
+			//when
+			final ResultActions perform = mockMvc.perform(
+				get(baseUrl + "/{profileId}/{tab}", user1ProfileId, "followee")
 					.header(AUTHORIZATION, token)
-					.contentType(APPLICATION_JSON))
+					.contentType(APPLICATION_JSON));
+
+			//then
+			perform
 				.andExpect(status().isOk())
 				.andExpectAll(
 					jsonPath("$.profiles", hasSize(1)),
 					jsonPath("$.profiles[0].profileId").value(user2ProfileId),
 					jsonPath("$.profiles[0].isFollow").value(true)
 				);
+		}
 
-			// user1 -> user2 의 팔로이 조회
-			mockMvc.perform(get(baseUrl + "/{profileId}/{tab}", user2ProfileId, "followee")
+		@Test
+		void 프로필_목록_조회_Api_성공_user1이_user2의_팔로이_조회() throws Exception {
+			//given
+			로그인("user1@gmail.com", GOOGLE);
+
+			//when
+			final ResultActions perform = mockMvc.perform(
+				get(baseUrl + "/{profileId}/{tab}", user2ProfileId, "followee")
 					.header(AUTHORIZATION, token)
-					.contentType(APPLICATION_JSON))
+					.contentType(APPLICATION_JSON));
+
+			//then
+			perform
 				.andExpect(status().isOk())
 				.andExpectAll(
 					jsonPath("$.profiles", hasSize(2)),
@@ -334,11 +375,22 @@ class ProfileControllerTest extends BaseControllerTest {
 					jsonPath("$.profiles[1].profileId").value(user3ProfileId),
 					jsonPath("$.profiles[1].isFollow").value(false)
 				);
+		}
 
+		@Test
+		void 프로필_목록_조회_Api_성공_user1이_user3의_팔로이_조회() throws Exception {
+			//given
+			로그인("user1@gmail.com", GOOGLE);
+
+			//when
 			// user1 -> user3 의 팔로이 조회
-			mockMvc.perform(get(baseUrl + "/{profileId}/{tab}", user3ProfileId, "followee")
+			final ResultActions perform = mockMvc.perform(
+				get(baseUrl + "/{profileId}/{tab}", user3ProfileId, "followee")
 					.header(AUTHORIZATION, token)
-					.contentType(APPLICATION_JSON))
+					.contentType(APPLICATION_JSON));
+
+			//then
+			perform
 				.andExpect(status().isOk())
 				.andExpect(jsonPath("$.profiles", hasSize(0)));
 		}

--- a/src/test/java/com/meoguri/linkocean/controller/user/LoginControllerTest.java
+++ b/src/test/java/com/meoguri/linkocean/controller/user/LoginControllerTest.java
@@ -10,6 +10,7 @@ import java.util.List;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.ResultActions;
 
 import com.meoguri.linkocean.controller.user.dto.LoginRequest;
 import com.meoguri.linkocean.test.support.controller.BaseControllerTest;
@@ -19,7 +20,7 @@ class LoginControllerTest extends BaseControllerTest {
 	private final String basePath = getBaseUrl(LoginController.class);
 
 	@Test
-	void 로그인_성공_Api() throws Exception {
+	void 로그인_Api_성공() throws Exception {
 		//given
 		final String email = "jk05018@naver.com";
 		final String oauthType = "NAVER";
@@ -27,49 +28,48 @@ class LoginControllerTest extends BaseControllerTest {
 		final LoginRequest loginRequest = new LoginRequest(email, oauthType);
 
 		//when
-		mockMvc.perform(post(basePath)
-				.contentType(MediaType.APPLICATION_JSON)
-				.content(createJson(loginRequest)))
+		final ResultActions perform = mockMvc.perform(post(basePath)
+			.contentType(MediaType.APPLICATION_JSON)
+			.content(createJson(loginRequest)));
 
-			//then
+		//then
+		perform
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.token").exists());
-
 	}
 
 	@Test
-	void 로그인_성공후_Profile_소지여부조회_Api_hasProfile_true() throws Exception {
+	void 프로필_존재_유무_조회_Api_성공_프로필_있음() throws Exception {
 		//given
 		유저_등록_로그인("hani@gmail.com", GOOGLE);
 		프로필_등록("hani", List.of("정치", "인문", "사회"));
 
 		//when
-		mockMvc.perform(get(basePath + "/success")
-				.header(AUTHORIZATION, token)
-				.contentType(MediaType.APPLICATION_JSON))
+		final ResultActions perform = mockMvc.perform(get(basePath + "/success")
+			.header(AUTHORIZATION, token)
+			.contentType(MediaType.APPLICATION_JSON));
 
-			//then
+		//then
+		perform
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.hasProfile").value(true))
 			.andDo(print());
-
 	}
 
 	@Test
-	void 로그인_성공후_Profile_소지여부조회_Api_hasProfile_false() throws Exception {
+	void 프로필_존재_유무_조회_Api_성공_프로필_없음() throws Exception {
 		//given
 		유저_등록_로그인("hani@gmail.com", GOOGLE);
 
 		//when
-		mockMvc.perform(get(basePath + "/success")
-				.header(AUTHORIZATION, token)
-				.contentType(MediaType.APPLICATION_JSON))
+		final ResultActions perform = mockMvc.perform(get(basePath + "/success")
+			.header(AUTHORIZATION, token)
+			.contentType(MediaType.APPLICATION_JSON));
 
-			//then
+		//then
+		perform
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.hasProfile").value(false))
 			.andDo(print());
-
 	}
-
 }

--- a/src/test/java/com/meoguri/linkocean/test/support/controller/BaseControllerTest.java
+++ b/src/test/java/com/meoguri/linkocean/test/support/controller/BaseControllerTest.java
@@ -12,8 +12,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Stream;
 
-import javax.persistence.EntityManager;
-
+import org.junit.jupiter.api.AfterEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.test.web.servlet.MockMvc;
@@ -35,12 +34,10 @@ import com.meoguri.linkocean.domain.user.entity.User;
 import com.meoguri.linkocean.domain.user.entity.vo.Email;
 import com.meoguri.linkocean.domain.user.entity.vo.OAuthType;
 import com.meoguri.linkocean.domain.user.persistence.UserRepository;
+import com.meoguri.linkocean.test.support.db.DatabaseCleanup;
 
 @ControllerTest
 public abstract class BaseControllerTest {
-
-	@Autowired
-	protected EntityManager em;
 
 	@Autowired
 	protected MockMvc mockMvc;
@@ -58,6 +55,14 @@ public abstract class BaseControllerTest {
 
 	@Autowired
 	private LinkMetadataRepository linkMetadataRepository;
+
+	@Autowired
+	private DatabaseCleanup databaseCleanup;
+
+	@AfterEach
+	void cleanUp() {
+		databaseCleanup.execute();
+	}
 
 	protected String createJson(Object dto) throws JsonProcessingException {
 		return objectMapper.writeValueAsString(dto);

--- a/src/test/java/com/meoguri/linkocean/test/support/controller/ControllerTest.java
+++ b/src/test/java/com/meoguri/linkocean/test/support/controller/ControllerTest.java
@@ -1,6 +1,7 @@
 package com.meoguri.linkocean.test.support.controller;
 
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -9,16 +10,16 @@ import org.junit.jupiter.api.Tag;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
-import org.springframework.transaction.annotation.Transactional;
 
+import com.meoguri.linkocean.test.support.db.DatabaseCleanup;
 import com.meoguri.linkocean.test.support.logging.p6spy.P6spyLogMessageFormatConfiguration;
 
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
+@Inherited
 @Tag("controller")
 @AutoConfigureMockMvc
-@Transactional
 @SpringBootTest
-@Import(P6spyLogMessageFormatConfiguration.class)
+@Import({P6spyLogMessageFormatConfiguration.class, DatabaseCleanup.class})
 public @interface ControllerTest {
 }


### PR DESCRIPTION
<!-- PR 제목 양식 예시: [LO-N] 회원 기능 도메인 -->

## 🛠️ 작업 내용
- 컨트롤러 테스트 @Transactional 제거 & 컨밴션에 맞게 리팩토링

## 🗨️ 기타
<!-- PR 포인트 혹은 궁금한 점 등등 적어주시면 됩니다. 없으시면 지워주세요 -->
- Controller 테스트에도 @Transactional을 제거했습니다.
- Controller 테스트 네이밍과, when/then 영역을 구분하는 작업을 했습니다..
- 너무 많은 것을 테스트하는 것 같은 테스트는 여러개의 테스트로 분리했습니다.

<hr/>

- 리팩토링 하다보니까 저희 알림 기능도 진짜 아픈 손가락이네요 ㅎㅎ
- 서비스와 컨트롤러 테스트의 트랜잭션을 제거해 프로덕션 코드와 비슷한 환경이 됐습니다. 하지만 단점으로 테스트 시간이 오래 걸리네요. 이것도 한번 최적화에 대해 공부한 다음 적용해보면 재밌을 것 같아요. 😄 

## 😎 리뷰어
@ndy2 , @jk05018
