### PR TITLE
[LO-218] 내 프로필 조회 태그 데이터 버그 해결

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,9 @@ services:
     container_name: mysql
     env_file:
       - env/mysql.env
+    command:
+      - --character-set-server=utf8mb4
+      - --collation-server=utf8mb4_unicode_ci
 
   migration:
     image: flyway/flyway:7.5.1

--- a/src/main/java/com/meoguri/linkocean/domain/bookmark/persistence/CustomBookmarkRepositoryImpl.java
+++ b/src/main/java/com/meoguri/linkocean/domain/bookmark/persistence/CustomBookmarkRepositoryImpl.java
@@ -1,6 +1,7 @@
 package com.meoguri.linkocean.domain.bookmark.persistence;
 
 import static com.meoguri.linkocean.domain.bookmark.entity.QBookmark.*;
+import static com.meoguri.linkocean.domain.bookmark.entity.vo.BookmarkStatus.*;
 import static com.meoguri.linkocean.domain.profile.entity.QFollow.*;
 import static com.meoguri.linkocean.domain.tag.entity.QTag.*;
 import static com.meoguri.linkocean.util.querydsl.CustomPath.*;
@@ -18,7 +19,6 @@ import org.springframework.data.querydsl.QPageRequest;
 import org.springframework.stereotype.Repository;
 
 import com.meoguri.linkocean.domain.bookmark.entity.Bookmark;
-import com.meoguri.linkocean.domain.bookmark.entity.vo.BookmarkStatus;
 import com.meoguri.linkocean.domain.bookmark.entity.vo.Category;
 import com.meoguri.linkocean.domain.bookmark.entity.vo.OpenType;
 import com.meoguri.linkocean.domain.bookmark.persistence.dto.BookmarkFindCond;
@@ -175,7 +175,7 @@ public class CustomBookmarkRepositoryImpl extends Querydsl4RepositorySupport imp
 	}
 
 	private BooleanBuilder registered() {
-		return nullSafeBuilder(() -> bookmark.status.eq(BookmarkStatus.REGISTERED));
+		return nullSafeBuilder(() -> bookmark.status.eq(REGISTERED));
 	}
 	// Spring Pageable -> QueryDsl Pageable
 
@@ -221,7 +221,8 @@ public class CustomBookmarkRepositoryImpl extends Querydsl4RepositorySupport imp
 			.where(bt_bookmarkId.in(
 				select(bookmark.id)
 					.from(bookmark)
-					.where(b_profileId.eq(profileId)))
+					.where(b_profileId.eq(profileId)
+						.and(b_status.eq(REGISTERED.name()))))
 			)
 			.groupBy(bt_tagId)
 			.fetch();

--- a/src/main/java/com/meoguri/linkocean/util/querydsl/CustomPath.java
+++ b/src/main/java/com/meoguri/linkocean/util/querydsl/CustomPath.java
@@ -48,9 +48,9 @@ public final class CustomPath {
 	/* bt.tag_id */
 	public static NumberPath<Long> bt_tagId = Expressions.numberPath(Long.class, bookmark_tag, "tag_id");
 
-	/* bt.profile_id */
+	/* bookmark.profile_id */
 	public static NumberPath<Long> b_profileId = Expressions.numberPath(Long.class, bookmark, "profile_id");
 
-	/* b.status */
+	/* bookmark.status */
 	public static StringPath b_status = Expressions.stringPath(bookmark, "status");
 }

--- a/src/main/java/com/meoguri/linkocean/util/querydsl/CustomPath.java
+++ b/src/main/java/com/meoguri/linkocean/util/querydsl/CustomPath.java
@@ -6,6 +6,7 @@ import com.meoguri.linkocean.domain.bookmark.entity.vo.ReactionType;
 import com.querydsl.core.types.dsl.EnumPath;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.core.types.dsl.NumberPath;
+import com.querydsl.core.types.dsl.StringPath;
 import com.querydsl.sql.RelationalPathBase;
 
 import lombok.NoArgsConstructor;
@@ -47,7 +48,9 @@ public final class CustomPath {
 	/* bt.tag_id */
 	public static NumberPath<Long> bt_tagId = Expressions.numberPath(Long.class, bookmark_tag, "tag_id");
 
-	/* bt.tag_id */
+	/* bt.profile_id */
 	public static NumberPath<Long> b_profileId = Expressions.numberPath(Long.class, bookmark, "profile_id");
 
+	/* b.status */
+	public static StringPath b_status = Expressions.stringPath(bookmark, "status");
 }

--- a/src/test/java/com/meoguri/linkocean/domain/bookmark/persistence/BookmarkRepositoryTest.java
+++ b/src/test/java/com/meoguri/linkocean/domain/bookmark/persistence/BookmarkRepositoryTest.java
@@ -59,7 +59,7 @@ class BookmarkRepositoryTest extends BasePersistenceTest {
 
 		//when
 		final Optional<Bookmark> oFoundBookmark =
-			bookmarkRepository.findByIdAndWriterId(savedBookmark.getId(), writerId);
+			pretty(() -> bookmarkRepository.findByIdAndWriterId(savedBookmark.getId(), writerId));
 
 		//then
 		assertThat(oFoundBookmark).isPresent().get().isEqualTo(savedBookmark);

--- a/src/test/java/com/meoguri/linkocean/domain/bookmark/persistence/CustomBookmarkRepositoryImplTest.java
+++ b/src/test/java/com/meoguri/linkocean/domain/bookmark/persistence/CustomBookmarkRepositoryImplTest.java
@@ -563,7 +563,8 @@ class CustomBookmarkRepositoryImplTest extends BasePersistenceTest {
 		북마크_링크_메타데이터_동시_저장(profile1, "링크오션", ALL, IT, "www.linkocean.com");
 
 		//when
-		final List<FindUsedTagIdWithCountResult> result = bookmarkRepository.findUsedTagIdsWithCount(profile1.getId());
+		final List<FindUsedTagIdWithCountResult> result =
+			pretty(() -> bookmarkRepository.findUsedTagIdsWithCount(profile1.getId()));
 
 		//then
 		assertThat(result)

--- a/src/test/java/com/meoguri/linkocean/domain/bookmark/service/BookmarkServiceImplTest.java
+++ b/src/test/java/com/meoguri/linkocean/domain/bookmark/service/BookmarkServiceImplTest.java
@@ -553,26 +553,47 @@ class BookmarkServiceImplTest extends BaseServiceTest {
 		assertThat(notDuplicated).isEmpty();
 	}
 
-	@Test
-	void 태그_목록_조회_성공() {
-		//given
-		final long profileId = 사용자_프로필_동시_등록("haha@gmail.com", GOOGLE, "haha", IT);
+	@Nested
+	class 태그_목록_조회 {
 
-		북마크_링크_메타데이터_동시_등록(profileId, "www.naver.com", "tag1", "tag2", "tag3");
-		북마크_링크_메타데이터_동시_등록(profileId, "www.google.com", "tag1", "tag2");
-		북마크_링크_메타데이터_동시_등록(profileId, "www.prgrms.com", "tag1");
+		private long profileId;
 
-		//when
-		final List<GetUsedTagWithCountResult> result = bookmarkService.getUsedTagsWithCount(profileId);
+		@BeforeEach
+		void setUp() {
+			profileId = 사용자_프로필_동시_등록("haha@gmail.com", GOOGLE, "haha", IT);
+		}
 
-		//then
-		assertThat(result).hasSize(3)
-			.extracting(GetUsedTagWithCountResult::getTag, GetUsedTagWithCountResult::getCount)
-			.containsExactly(
-				tuple("tag1", 3L),
-				tuple("tag2", 2L),
-				tuple("tag3", 1L)
-			);
+		@Test
+		void 태그_목록_조회_성공() {
+			//given
+			북마크_링크_메타데이터_동시_등록(profileId, "www.naver.com", "tag1", "tag2", "tag3");
+			북마크_링크_메타데이터_동시_등록(profileId, "www.google.com", "tag1", "tag2");
+			북마크_링크_메타데이터_동시_등록(profileId, "www.prgrms.com", "tag1");
+
+			//when
+			final List<GetUsedTagWithCountResult> result = bookmarkService.getUsedTagsWithCount(profileId);
+
+			//then
+			assertThat(result).hasSize(3)
+				.extracting(GetUsedTagWithCountResult::getTag, GetUsedTagWithCountResult::getCount)
+				.containsExactly(
+					tuple("tag1", 3L),
+					tuple("tag2", 2L),
+					tuple("tag3", 1L)
+				);
+		}
+
+		@Test
+		void 태그_목록_조회_성공_삭제된_북마크는_조회_안됨() {
+			//given
+			final long bookmarkId = 북마크_링크_메타데이터_동시_등록(profileId, "www.prgrms.com", "tag1");
+			북마크_삭제(profileId, bookmarkId);
+
+			//when
+			final List<GetUsedTagWithCountResult> result = bookmarkService.getUsedTagsWithCount(profileId);
+
+			//then
+			assertThat(result).isEmpty();
+		}
 	}
-
 }

--- a/src/test/java/com/meoguri/linkocean/test/support/domain/persistence/BasePersistenceTest.java
+++ b/src/test/java/com/meoguri/linkocean/test/support/domain/persistence/BasePersistenceTest.java
@@ -5,6 +5,7 @@ import static com.meoguri.linkocean.domain.bookmark.entity.vo.ReactionType.*;
 import static java.util.stream.Collectors.*;
 
 import java.util.Arrays;
+import java.util.function.Supplier;
 
 import javax.persistence.EntityManager;
 import javax.persistence.EntityManagerFactory;
@@ -31,15 +32,10 @@ import com.meoguri.linkocean.domain.user.entity.User;
 import com.meoguri.linkocean.domain.user.entity.vo.Email;
 import com.meoguri.linkocean.domain.user.entity.vo.OAuthType;
 import com.meoguri.linkocean.domain.user.persistence.UserRepository;
+import com.meoguri.linkocean.test.support.logging.p6spy.P6spyLogMessageFormatConfiguration;
 
 @PersistenceTest
 public abstract class BasePersistenceTest {
-
-	@Autowired
-	protected EntityManager em;
-
-	@Autowired
-	protected EntityManagerFactory emf;
 
 	@Autowired
 	private UserRepository userRepository;
@@ -55,6 +51,16 @@ public abstract class BasePersistenceTest {
 
 	@Autowired
 	private BookmarkRepository bookmarkRepository;
+
+	@Autowired
+	protected EntityManager em;
+
+	@Autowired
+	protected EntityManagerFactory emf;
+
+	protected <T> T pretty(final Supplier<T> supplier) {
+		return P6spyLogMessageFormatConfiguration.pretty(supplier, em);
+	}
 
 	protected boolean isLoaded(final Object entity) {
 		return emf.getPersistenceUnitUtil().isLoaded(entity);

--- a/src/test/java/com/meoguri/linkocean/test/support/domain/service/BaseServiceTest.java
+++ b/src/test/java/com/meoguri/linkocean/test/support/domain/service/BaseServiceTest.java
@@ -115,6 +115,10 @@ public abstract class BaseServiceTest {
 		);
 	}
 
+	protected void 북마크_삭제(final long writerId, final long bookmarkId) {
+		bookmarkService.removeBookmark(writerId, bookmarkId);
+	}
+
 	protected long 북마크_링크_메타데이터_동시_등록(final long writerId, final String url, final OpenType openType) {
 		return 북마크_링크_메타데이터_동시_등록(writerId, url, null, null, null, openType);
 	}

--- a/src/test/java/com/meoguri/linkocean/test/support/logging/p6spy/P6spyLogMessageFormatConfiguration.java
+++ b/src/test/java/com/meoguri/linkocean/test/support/logging/p6spy/P6spyLogMessageFormatConfiguration.java
@@ -1,5 +1,7 @@
 package com.meoguri.linkocean.test.support.logging.p6spy;
 
+import java.util.function.Supplier;
+
 import javax.annotation.PostConstruct;
 import javax.persistence.EntityManager;
 
@@ -24,14 +26,16 @@ public class P6spyLogMessageFormatConfiguration {
 	}
 
 	/* target 을 pretty 포맷으로 실행하고 oneline 포맷 으로 변경 */
-	public static void pretty(final Runnable target, final EntityManager em) {
+	public static <T> T pretty(final Supplier<T> supplier, final EntityManager em) {
 		em.flush();
 		pretty();
 
-		target.run();
+		final T result = supplier.get();
 
 		em.flush();
 		oneline();
+
+		return result;
 	}
 
 }


### PR DESCRIPTION
<!-- PR 제목 양식 예시: [LO-N] 회원 기능 도메인 -->

## 🛠️ 작업 내용
- 내 프로필 조회 태그 데이터 버그 해결

## 🗨️ 기타
<!-- PR 포인트 혹은 궁금한 점 등등 적어주시면 됩니다. 없으시면 지워주세요 -->
- 내 프로필 목록 조회에 태그 데이터에서 삭제된 북마크도 포함되는 버그가 있었습니다. [참조](https://www.notion.so/backend-devcourse/64b3797f04c34b878a430f21a0bfaf82)
- 관련 쿼리 수정했습니다
  - JpasqlQeury를 사용하니까 EnumPath 직렬화를 의도한데로 못해주는 것 같아요 [참조](https://github.com/querydsl/querydsl/issues/419)
  - 그래서 StringPath로 우회하는 방법을 사용했습니다.

## 😎 리뷰어
@ndy2 , @jk05018 
