### PR TITLE
[LO-220] 다른 사람 북마크 목록 조회 태그 필터링 버그 해결

### DIFF
--- a/src/main/java/com/meoguri/linkocean/domain/bookmark/persistence/CustomBookmarkRepositoryImpl.java
+++ b/src/main/java/com/meoguri/linkocean/domain/bookmark/persistence/CustomBookmarkRepositoryImpl.java
@@ -109,16 +109,15 @@ public class CustomBookmarkRepositoryImpl extends Querydsl4RepositorySupport imp
 			.where(CustomPath.profileId.eq(profileId))
 			.fetch();
 	}
-	/* 태그를 포함한 북마크의 id 를 역으로 조회 */
 
+	/* 태그를 포함한 북마크의 id 를 역으로 조회 */
 	private List<Long> getBookmarkIds(final List<String> tags) {
 		return tags != null ? getJpasqlQuery().select(bt_bookmarkId)
 			.distinct()
 			.from(bookmark_tag)
-			.join(tag)
+			.join(tag).on(bt_tagId.eq(tag.id))
 			.where(tag.name.in(tags))
 			.fetch() : null;
-
 	}
 
 	private BooleanBuilder titleContains(final String title) {

--- a/src/main/resources/db/migration/V022__Alter_tag.sql
+++ b/src/main/resources/db/migration/V022__Alter_tag.sql
@@ -1,0 +1,1 @@
+alter table tag modify name varchar(50) collate utf8mb4_bin;

--- a/src/test/java/com/meoguri/linkocean/domain/bookmark/persistence/CustomBookmarkRepositoryImplTest.java
+++ b/src/test/java/com/meoguri/linkocean/domain/bookmark/persistence/CustomBookmarkRepositoryImplTest.java
@@ -192,7 +192,7 @@ class CustomBookmarkRepositoryImplTest extends BasePersistenceTest {
 				.build();
 			final Pageable pageable = createPageable("like");
 
-			// when
+			//when
 			final Page<Bookmark> bookmarks = bookmarkRepository.findBookmarks(findCond, pageable);
 
 			//then
@@ -269,7 +269,7 @@ class CustomBookmarkRepositoryImplTest extends BasePersistenceTest {
 			final Pageable pageable = createPageable("upload");
 
 			//when
-			final Page<Bookmark> bookmarkPage = bookmarkRepository.findBookmarks(findCond, pageable);
+			final Page<Bookmark> bookmarkPage = pretty(() -> bookmarkRepository.findBookmarks(findCond, pageable));
 
 			//then
 			assertThat(bookmarkPage).hasSize(2);
@@ -280,6 +280,42 @@ class CustomBookmarkRepositoryImplTest extends BasePersistenceTest {
 
 			assertThat(bookmarkPage.getContent().get(1).getId()).isEqualTo(bookmarkId1);
 			assertThat(bookmarkPage.getContent().get(1).getTagIds()).containsExactlyInAnyOrder(tagId1, tagId2);
+		}
+
+		@Test
+		void 북마크_태그로_조회_성공_대_소문자_구분() {
+			//given
+			final BookmarkFindCond findCond = BookmarkFindCond.builder()
+				.targetProfileId(profileId)
+				.tags(List.of("Tag1"))
+				.build();
+			final Pageable pageable = createPageable("upload");
+
+			//when
+			final Page<Bookmark> bookmarkPage = pretty(() -> bookmarkRepository.findBookmarks(findCond, pageable));
+
+			//then
+			assertThat(bookmarkPage).isEmpty();
+		}
+
+		@Test
+		void 북마크_태그로_조회_성공_한글_태그() {
+			//given
+			북마크_저장(profile, "https://test1.com", 태그_저장("한국말").getId());
+			북마크_저장(profile, "https://test2.com", 태그_저장("카카오").getId());
+			북마크_저장(profile, "https://test3.com", 태그_저장("구글").getId());
+
+			final BookmarkFindCond findCond = BookmarkFindCond.builder()
+				.targetProfileId(profileId)
+				.tags(List.of("한국말"))
+				.build();
+			final Pageable pageable = createPageable("upload");
+
+			//when
+			final Page<Bookmark> bookmarkPage = pretty(() -> bookmarkRepository.findBookmarks(findCond, pageable));
+
+			//then
+			assertThat(bookmarkPage).hasSize(1);
 		}
 
 		@Test

--- a/src/test/java/com/meoguri/linkocean/domain/tag/persistence/TagRepositoryTest.java
+++ b/src/test/java/com/meoguri/linkocean/domain/tag/persistence/TagRepositoryTest.java
@@ -17,17 +17,28 @@ class TagRepositoryTest extends BasePersistenceTest {
 	@Autowired
 	private TagRepository tagRepository;
 
-	/* Note - mysql varchar case-insensitive */
 	@Test
 	void 이름으로_조회_성공() {
 		//given
 		final Tag savedTag = 태그_저장("tag태그");
 
 		//when
-		final Optional<Tag> oFoundTag = tagRepository.findByName("TAG태그");
+		final Optional<Tag> oFoundTag = tagRepository.findByName(savedTag.getName());
 
 		//then
 		assertThat(oFoundTag).isPresent().get().isEqualTo(savedTag);
+	}
+
+	@Test
+	void 이름으로_조회_대_소문자_구분() {
+		//given
+		final Tag savedTag = 태그_저장("fun");
+
+		//when
+		final Optional<Tag> oFoundTag = pretty(() -> tagRepository.findByName(savedTag.getName().toUpperCase()));
+
+		//then
+		assertThat(oFoundTag).isEmpty();
 	}
 
 	@Test

--- a/src/test/java/com/meoguri/linkocean/test/support/domain/persistence/BasePersistenceTest.java
+++ b/src/test/java/com/meoguri/linkocean/test/support/domain/persistence/BasePersistenceTest.java
@@ -1,5 +1,6 @@
 package com.meoguri.linkocean.test.support.domain.persistence;
 
+import static com.meoguri.linkocean.domain.bookmark.entity.vo.Category.*;
 import static com.meoguri.linkocean.domain.bookmark.entity.vo.OpenType.*;
 import static com.meoguri.linkocean.domain.bookmark.entity.vo.ReactionType.*;
 import static java.util.stream.Collectors.*;
@@ -106,6 +107,10 @@ public abstract class BasePersistenceTest {
 		return 북마크_저장(writer, linkMetadata, null, null, ALL, null, url);
 	}
 
+	protected Bookmark 북마크_저장(final Profile writer, final String url, final long... tagIds) {
+		return 북마크_저장(writer, null, "title", "memo", ALL, IT, url, tagIds);
+	}
+
 	protected Bookmark 북마크_저장(final Profile writer, final LinkMetadata linkMetadata, final OpenType openType,
 		final String url) {
 		return 북마크_저장(writer, linkMetadata, null, null, openType, null, url);
@@ -122,7 +127,7 @@ public abstract class BasePersistenceTest {
 		final long... tagIds
 	) {
 		return bookmarkRepository.save(new Bookmark(writer,
-			linkMetadata.getId(),
+			linkMetadata != null ? linkMetadata.getId() : null,
 			title,
 			memo,
 			openType,

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -9,7 +9,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: validate
     properties:
       hibernate:
         dialect: org.hibernate.dialect.MySQL8Dialect
@@ -18,7 +18,7 @@ spring:
     show-sql: false
 
   flyway:
-    enabled: false
+    enabled: true
 
 jwt:
   secret-key: test


### PR DESCRIPTION
<!-- PR 제목 양식 예시: [LO-N] 회원 기능 도메인 -->

## 🛠️ 작업 내용
- 다른 사람 북마크 목록 조회 태그 필터링 버그 해결

## 🗨️ 기타
<!-- PR 포인트 혹은 궁금한 점 등등 적어주시면 됩니다. 없으시면 지워주세요 -->
- 다른 사람 북마크 조회시 태그 필터링이 제대로 동작하지 않는 이슈가 있었습니다. [참조](https://www.notion.so/backend-devcourse/fc2d07433c3e420497a5f801246e118b)
  - 조인할때 on 절 조건을 빼먹어 카타시안 연산이 적용됐습니다. 이를 알맞게 수정했습니다.
  - 관련 테스트도 추가했습니다.
- 추가로 tag 테이블의 collation 변경으로 태그 이름도 대소문자 구분이 가능합니다.
- 테스트 설정에서 ddl-auto를 사용하는 것이 아니라, validate로 바꿨습니다. 이유는 tag 테이블의 name 컬럼의 collation 옵션이 바뀌면서 이를 tag 엔티티에 표시해줄까 고민했습니다. 제가 내린 결론은 코드가 지저분해 지는 것 같아 따로 표시하지 않았습니다. 그래서 jpa가 만들어주는 ddl과 flyway ddl의 차이가 생겼습니다. 그래서 ddl-auto는 제거하고 flyway를 사용하는 방식으로 바꿨습니다.

<hr/>

- 테스트를 나름 꼼꼼히 작성한 것 같은데, 빼먹은 시나리오들이 많네요.. ㅎㅎ 

## 😎 리뷰어
@ndy2 , @jk05018 
