### PR TITLE
[LO-222] 북마크 오픈타입 정책 변경

### DIFF
--- a/src/main/java/com/meoguri/linkocean/domain/bookmark/entity/vo/OpenType.java
+++ b/src/main/java/com/meoguri/linkocean/domain/bookmark/entity/vo/OpenType.java
@@ -13,9 +13,6 @@ public enum OpenType {
 	/* 전체공개 */
 	ALL((byte)10),
 
-	/* 팔로워 대상 공개 */
-	PARTIAL((byte)20),
-
 	/* 개인 공개 */
 	PRIVATE((byte)30);
 

--- a/src/main/java/com/meoguri/linkocean/domain/bookmark/persistence/CustomBookmarkRepositoryImpl.java
+++ b/src/main/java/com/meoguri/linkocean/domain/bookmark/persistence/CustomBookmarkRepositoryImpl.java
@@ -152,7 +152,7 @@ public class CustomBookmarkRepositoryImpl extends Querydsl4RepositorySupport imp
 		));
 	}
 
-	// 작성자 id 대상 북마크 조회에서 사용
+	/* 작성자 id 대상 북마크 조회에서 사용 */
 	private BooleanBuilder availableByOpenType(final OpenType openType) {
 		// PRIVATE 이상을 조회 하는 요청이므로 필터링이 필요 없음
 		if (openType == OpenType.PRIVATE) {
@@ -163,12 +163,12 @@ public class CustomBookmarkRepositoryImpl extends Querydsl4RepositorySupport imp
 		return nullSafeBuilder(() -> bookmark.openType.loe(openType));
 	}
 
-	// 피드 조회에서 사용
-	// 전체 공개 북마크, 팔로우 중인 사용자의 일부 공개 북마크, 자신의 북마크 (private 포함) 에 접근 가능하다
+	/* 피드 조회에서 사용 */
+	/* 전체 공개 북마크, 자신의 북마크 (private 포함) 에 접근 가능하다 */
 	private BooleanBuilder availableByOpenType(long currentUserProfileId) {
 		return nullSafeBuilder(() ->
 			bookmark.openType.eq(OpenType.ALL)
-				.or(bookmark.openType.eq(OpenType.PARTIAL).and(followedBy(currentUserProfileId)))
+				// .or(bookmark.openType.eq(OpenType.PARTIAL).and(followedBy(currentUserProfileId)))
 				.or(bookmark.writer.id.eq(currentUserProfileId))
 		);
 	}

--- a/src/main/java/com/meoguri/linkocean/domain/bookmark/persistence/dto/BookmarkFindCond.java
+++ b/src/main/java/com/meoguri/linkocean/domain/bookmark/persistence/dto/BookmarkFindCond.java
@@ -45,9 +45,10 @@ public final class BookmarkFindCond {
 
 	/* 공개 범위 조건 - 북마크 작성자와 자신의 관계에 따라 결정 된다
 	   조건은 계층적이다
-	   현재 사용자가 북마크 조회 대상 사용자 인 경우 PRIVATE 		-> PRIVATE, PARTIAL, ALL 모든 북마크에 접근 가능
-	   현재 사용자가 북마크 조회 대상을 팔로우 중인 경우 PARTIAL 	-> PARTIAL, ALL 북마크에 접근 가능
-	   그 외의 경우 ALL								 	-> ALL 북마크만 접근 가능 .*/
+	   현재 사용자가 북마크 조회 대상 사용자 인 경우 PRIVATE 		-> PRIVATE, ALL 모든 북마크에 접근 가능
+	   다른 사용자의 북마크 조회 	                            -> ALL 북마크에 접근 가능
+
+	   피드 북마크 조회								 	    -> 내 북마크 PRIVATE, ALL, 다른 사람 북마크 ALL 북마크만 접근 가능 .*/
 	@Setter
 	private OpenType openType;
 }

--- a/src/main/java/com/meoguri/linkocean/domain/profile/entity/Profile.java
+++ b/src/main/java/com/meoguri/linkocean/domain/profile/entity/Profile.java
@@ -140,11 +140,8 @@ public class Profile extends BaseIdEntity {
 	public OpenType getAvailableBookmarkOpenType(final Profile target) {
 		if (this.equals(target)) {
 			return OpenType.PRIVATE;
-		} else if (this.isFollow(target)) {
-			return OpenType.PARTIAL;
-		} else {
-			return OpenType.ALL;
 		}
+		return OpenType.ALL;
 	}
 
 }

--- a/src/test/java/com/meoguri/linkocean/controller/bookmark/BookmarkControllerTest.java
+++ b/src/test/java/com/meoguri/linkocean/controller/bookmark/BookmarkControllerTest.java
@@ -214,7 +214,7 @@ class BookmarkControllerTest extends BaseControllerTest {
 		@BeforeEach
 		void setUp() throws Exception {
 			bookmarkId1 = 북마크_등록(링크_메타데이터_얻기("https://www.naver.com"), "title1", "IT", List.of("공부"), "all");
-			bookmarkId2 = 북마크_등록(링크_메타데이터_얻기("https://www.airbnb.co.kr"), "title2", "여행", List.of("travel"), "partial");
+			bookmarkId2 = 북마크_등록(링크_메타데이터_얻기("https://www.airbnb.co.kr"), "title2", "여행", List.of("travel"), "private");
 		}
 
 		@Test
@@ -353,7 +353,7 @@ class BookmarkControllerTest extends BaseControllerTest {
 			otherProfileId = 프로필_등록("user1", List.of("IT"));
 
 			bookmarkId1 = 북마크_등록(링크_메타데이터_얻기("https://www.naver.com"), "title1", "IT", List.of("공부"), "all");
-			bookmarkId2 = 북마크_등록(링크_메타데이터_얻기("https://www.airbnb.co.kr"), "title2", "여행", List.of("travel"), "partial");
+			bookmarkId2 = 북마크_등록(링크_메타데이터_얻기("https://www.airbnb.co.kr"), "title2", "여행", List.of("travel"), "all");
 			북마크_등록(링크_메타데이터_얻기("https://programmers.co.kr"), "title3", "기술", List.of("공부", "코테"), "private");
 			bookmarkId4 = 북마크_등록(링크_메타데이터_얻기("https://www.google.com"), "title4", "자기계발", List.of("머구리"), "all");
 
@@ -371,11 +371,13 @@ class BookmarkControllerTest extends BaseControllerTest {
 			perform
 				.andExpect(status().isOk())
 				.andExpectAll(
-					jsonPath("$.totalCount").value(2),
+					jsonPath("$.totalCount").value(3),
 					jsonPath("$.bookmarks[0].id").value(bookmarkId4),
 					jsonPath("$.bookmarks[0].openType").value("all"),
-					jsonPath("$.bookmarks[1].id").value(bookmarkId1),
-					jsonPath("$.bookmarks[1].openType").value("all"))
+					jsonPath("$.bookmarks[1].id").value(bookmarkId2),
+					jsonPath("$.bookmarks[1].openType").value("all"),
+					jsonPath("$.bookmarks[2].id").value(bookmarkId1),
+					jsonPath("$.bookmarks[2].openType").value("all"))
 				.andDo(print());
 		}
 
@@ -397,7 +399,7 @@ class BookmarkControllerTest extends BaseControllerTest {
 					jsonPath("$.bookmarks[0].id").value(bookmarkId4),
 					jsonPath("$.bookmarks[0].openType").value("all"),
 					jsonPath("$.bookmarks[1].id").value(bookmarkId2),
-					jsonPath("$.bookmarks[1].openType").value("partial"),
+					jsonPath("$.bookmarks[1].openType").value("all"),
 					jsonPath("$.bookmarks[2].id").value(bookmarkId1),
 					jsonPath("$.bookmarks[2].openType").value("all"))
 				.andDo(print());
@@ -495,11 +497,14 @@ class BookmarkControllerTest extends BaseControllerTest {
 			perform
 				.andExpect(status().isOk())
 				.andExpectAll(
-					jsonPath("$.totalCount").value(2),
+					jsonPath("$.totalCount").value(3),
 					jsonPath("$.bookmarks[0].id").value(bookmarkId1),
 					jsonPath("$.bookmarks[0].likeCount").value(1),
 					jsonPath("$.bookmarks[1].id").value(bookmarkId4),
-					jsonPath("$.bookmarks[1].likeCount").value(0));
+					jsonPath("$.bookmarks[1].likeCount").value(0),
+					jsonPath("$.bookmarks[2].id").value(bookmarkId2),
+					jsonPath("$.bookmarks[2].likeCount").value(0)
+				);
 		}
 	}
 
@@ -519,6 +524,7 @@ class BookmarkControllerTest extends BaseControllerTest {
 		private long bookmarkId8;
 
 		private long bookmarkId10;
+		private long bookmarkId11;
 
 		@BeforeEach
 		void setUp() throws Exception {
@@ -526,21 +532,21 @@ class BookmarkControllerTest extends BaseControllerTest {
 			프로필_등록("user3", List.of("IT"));
 
 			북마크_등록(링크_메타데이터_얻기("https://www.github.com"), "private");
-			북마크_등록(링크_메타데이터_얻기("https://www.google.com"), "partial");
+			bookmarkId11 = 북마크_등록(링크_메타데이터_얻기("https://www.google.com"), "all");
 			bookmarkId10 = 북마크_등록(링크_메타데이터_얻기("https://www.naver.com"), "all");
 
 			유저_등록_로그인("user2@gmail.com", GOOGLE);
 			final long profileId2 = 프로필_등록("user2", List.of("IT"));
 
 			북마크_등록(링크_메타데이터_얻기("https://www.github.com"), "private");
-			bookmarkId8 = 북마크_등록(링크_메타데이터_얻기("https://www.google.com"), "partial");
+			bookmarkId8 = 북마크_등록(링크_메타데이터_얻기("https://www.google.com"), "all");
 			bookmarkId7 = 북마크_등록(링크_메타데이터_얻기("https://www.naver.com"), "all");
 
 			유저_등록_로그인("user1@gmail.com", GOOGLE);
 			프로필_등록("user1", List.of("IT"));
 
 			bookmarkId6 = 북마크_등록(링크_메타데이터_얻기("https://www.github.com"), "private");
-			bookmarkId5 = 북마크_등록(링크_메타데이터_얻기("https://www.google.com"), "partial");
+			bookmarkId5 = 북마크_등록(링크_메타데이터_얻기("https://www.google.com"), "all");
 			bookmarkId4 = 북마크_등록(링크_메타데이터_얻기("https://www.naver.com"), "all");
 
 			팔로우(profileId2);
@@ -557,14 +563,15 @@ class BookmarkControllerTest extends BaseControllerTest {
 			perform
 				.andExpect(status().isOk())
 				.andExpectAll(
-					jsonPath("$.totalCount").value(6),
-					jsonPath("$.bookmarks", hasSize(6)),
+					jsonPath("$.totalCount").value(7),
+					jsonPath("$.bookmarks", hasSize(7)),
 					jsonPath("$.bookmarks[0].id").value(bookmarkId4),
 					jsonPath("$.bookmarks[1].id").value(bookmarkId5),
 					jsonPath("$.bookmarks[2].id").value(bookmarkId6),
 					jsonPath("$.bookmarks[3].id").value(bookmarkId7),
 					jsonPath("$.bookmarks[4].id").value(bookmarkId8),
-					jsonPath("$.bookmarks[5].id").value(bookmarkId10)
+					jsonPath("$.bookmarks[5].id").value(bookmarkId10),
+					jsonPath("$.bookmarks[6].id").value(bookmarkId11)
 				).andDo(print());
 		}
 

--- a/src/test/java/com/meoguri/linkocean/controller/notification/NotificationControllerTest.java
+++ b/src/test/java/com/meoguri/linkocean/controller/notification/NotificationControllerTest.java
@@ -33,7 +33,7 @@ class NotificationControllerTest extends BaseControllerTest {
 
 		유저_등록_로그인("target@gmail.com", GOOGLE);
 		targetProfileId = 프로필_등록("target", List.of("IT"));
-		unsharableBookmarkId = 북마크_등록(링크_메타데이터_얻기("http://www.naver.com"), null, emptyList(), "partial");
+		unsharableBookmarkId = 북마크_등록(링크_메타데이터_얻기("http://www.naver.com"), null, emptyList(), "private");
 		팔로우(senderProfileId);
 	}
 
@@ -101,7 +101,7 @@ class NotificationControllerTest extends BaseControllerTest {
 	}
 
 	@Test
-	void 공유_알림_생성_Api_실패_북마크_공개범위_일부_공개() throws Exception {
+	void 공유_알림_생성_Api_실패_북마크_공개범위_private() throws Exception {
 		//given
 		로그인("sender@gmail.com", GOOGLE);
 		final Map<String, Object> request = Map.of(

--- a/src/test/java/com/meoguri/linkocean/domain/bookmark/persistence/CustomBookmarkRepositoryImplTest.java
+++ b/src/test/java/com/meoguri/linkocean/domain/bookmark/persistence/CustomBookmarkRepositoryImplTest.java
@@ -52,7 +52,7 @@ class CustomBookmarkRepositoryImplTest extends BasePersistenceTest {
 		tagId2 = 태그_저장("tag2").getId();
 
 		bookmark1 = 북마크_링크_메타데이터_동시_저장(profile, "title1", ALL, IT, "www.naver.com", tagId1, tagId2);
-		bookmark2 = 북마크_링크_메타데이터_동시_저장(profile, "title2", PARTIAL, HOME, "www.google.com", tagId1);
+		bookmark2 = 북마크_링크_메타데이터_동시_저장(profile, "title2", ALL, HOME, "www.google.com", tagId1);
 		bookmark3 = 북마크_링크_메타데이터_동시_저장(profile, "title3", PRIVATE, IT, "www.github.com");
 
 		즐겨찾기_저장(profile, bookmark1);
@@ -391,11 +391,11 @@ class CustomBookmarkRepositoryImplTest extends BasePersistenceTest {
 		}
 
 		@Test
-		void 북마크_기본_조회_Partial_공개범위_성공() {
+		void 북마크_기본_조회_다른_사용자_북마크() {
 			//given
 			final BookmarkFindCond findCond = BookmarkFindCond.builder()
 				.targetProfileId(profileId)
-				.openType(PARTIAL)
+				.openType(ALL)
 				.build();
 			final Pageable pageable = createPageable("upload");
 
@@ -499,6 +499,7 @@ class CustomBookmarkRepositoryImplTest extends BasePersistenceTest {
 		private Bookmark bookmark8;
 
 		private Bookmark bookmark10;
+		private Bookmark bookmark11;
 
 		//  사용자 1 			-팔로우->	사용자 2 				사용자 3
 		// bookmark4 all,    		bookmark7 all, 		bookmark10 all
@@ -518,15 +519,15 @@ class CustomBookmarkRepositoryImplTest extends BasePersistenceTest {
 			LinkMetadata naver = 링크_메타데이터_저장("www.naver.com", "네이버", "naver.png");
 
 			북마크_저장(profile3, github, PRIVATE, "www.github.com");
-			북마크_저장(profile3, google, PARTIAL, "www.github.com");
+			bookmark11 = 북마크_저장(profile3, google, ALL, "www.github.com");
 			bookmark10 = 북마크_저장(profile3, naver, ALL, "naver.com");
 
 			북마크_저장(profile2, github, PRIVATE, "www.github.com");
-			bookmark8 = 북마크_저장(profile2, google, PARTIAL, "github.com");
+			bookmark8 = 북마크_저장(profile2, google, ALL, "github.com");
 			bookmark7 = 북마크_저장(profile2, naver, ALL, "google.com");
 
 			bookmark6 = 북마크_저장(profile1, github, PRIVATE, "naver.com");
-			bookmark5 = 북마크_저장(profile1, google, PARTIAL, "github.com");
+			bookmark5 = 북마크_저장(profile1, google, ALL, "github.com");
 			bookmark4 = 북마크_저장(profile1, naver, ALL, "google.com");
 		}
 
@@ -542,10 +543,10 @@ class CustomBookmarkRepositoryImplTest extends BasePersistenceTest {
 			final Page<Bookmark> bookmarkPage = bookmarkRepository.findBookmarks(findCond, pageable);
 
 			//then
-			assertThat(bookmarkPage).hasSize(6);
+			assertThat(bookmarkPage).hasSize(7);
 			assertThat(bookmarkPage.getContent())
-				.containsExactly(bookmark4, bookmark5, bookmark6, bookmark7, bookmark8, bookmark10);
-			assertThat(bookmarkPage.getTotalElements()).isEqualTo(6);
+				.containsExactly(bookmark4, bookmark5, bookmark6, bookmark7, bookmark8, bookmark10, bookmark11);
+			assertThat(bookmarkPage.getTotalElements()).isEqualTo(7);
 		}
 
 		@Test
@@ -581,7 +582,7 @@ class CustomBookmarkRepositoryImplTest extends BasePersistenceTest {
 			//then
 			assertThat(bookmarkPage).hasSize(2);
 			assertThat(bookmarkPage.getContent()).containsExactly(bookmark4, bookmark5);
-			assertThat(bookmarkPage.getTotalElements()).isEqualTo(6);
+			assertThat(bookmarkPage.getTotalElements()).isEqualTo(7);
 		}
 
 	}

--- a/src/test/java/com/meoguri/linkocean/domain/bookmark/service/BookmarkServiceImplTest.java
+++ b/src/test/java/com/meoguri/linkocean/domain/bookmark/service/BookmarkServiceImplTest.java
@@ -316,7 +316,7 @@ class BookmarkServiceImplTest extends BaseServiceTest {
 			profileId1 = 사용자_프로필_동시_등록("haha@gmail.com", GOOGLE, "haha", IT);
 			bookmarkId1 = 북마크_링크_메타데이터_동시_등록(profileId1, "http://www.naver.com", "title1", null, IT, ALL, "tag1",
 				"tag2");
-			bookmarkId2 = 북마크_링크_메타데이터_동시_등록(profileId1, "http://www.daum.com", "title2", null, IT, PARTIAL, "tag2");
+			bookmarkId2 = 북마크_링크_메타데이터_동시_등록(profileId1, "http://www.daum.com", "title2", null, IT, ALL, "tag2");
 			bookmarkId3 = 북마크_링크_메타데이터_동시_등록(profileId1, "http://www.kakao.com", "title3", null, HOME, PRIVATE, "tag1");
 
 			profileId2 = 사용자_프로필_동시_등록("crush@gmail.com", GOOGLE, "crush", IT);
@@ -338,9 +338,9 @@ class BookmarkServiceImplTest extends BaseServiceTest {
 			final Page<GetBookmarksResult> resultPage = bookmarkService.getByTargetProfileId(findCond, pageable);
 
 			//then
-			assertThat(resultPage.getContent()).hasSize(1)
+			assertThat(resultPage.getContent()).hasSize(2)
 				.extracting(GetBookmarksResult::getId, GetBookmarksResult::getOpenType)
-				.containsExactly(tuple(bookmarkId1, ALL));
+				.containsExactly(tuple(bookmarkId2, ALL), tuple(bookmarkId1, ALL));
 		}
 
 		@Test
@@ -361,7 +361,7 @@ class BookmarkServiceImplTest extends BaseServiceTest {
 				.containsExactly(tuple(bookmarkId4, null));
 		}
 
-		/* 다른 사람과 팔로우/팔로이 관계기 때문에 공개 범위가 all, partial 인 글을 볼 수 있다 */
+		/* 다른 사람과 팔로우/팔로이 관계기 때문에 공개 범위가 all 인 글을 볼 수 있다 */
 		@Test
 		void 팔로워_팔로이_관계인_사람의_북마크_목록_조회() {
 			//given
@@ -378,7 +378,7 @@ class BookmarkServiceImplTest extends BaseServiceTest {
 			//then
 			assertThat(resultPage.getContent()).hasSize(2)
 				.extracting(GetBookmarksResult::getId, GetBookmarksResult::getOpenType)
-				.containsExactly(tuple(bookmarkId2, PARTIAL), tuple(bookmarkId1, ALL));
+				.containsExactly(tuple(bookmarkId2, ALL), tuple(bookmarkId1, ALL));
 		}
 
 		@Test
@@ -398,7 +398,7 @@ class BookmarkServiceImplTest extends BaseServiceTest {
 				.extracting(GetBookmarksResult::getId, GetBookmarksResult::getOpenType)
 				.containsExactly(
 					tuple(bookmarkId3, PRIVATE),
-					tuple(bookmarkId2, PARTIAL),
+					tuple(bookmarkId2, ALL),
 					tuple(bookmarkId1, ALL)
 				);
 		}
@@ -456,11 +456,11 @@ class BookmarkServiceImplTest extends BaseServiceTest {
 			bookmarkId10 = 북마크_링크_메타데이터_동시_등록(profileId3, "www.naver.com", ALL);
 
 			북마크_링크_메타데이터_동시_등록(profileId2, "www.github.com", PRIVATE);
-			bookmarkId8 = 북마크_링크_메타데이터_동시_등록(profileId2, "www.kakao.com", PARTIAL);
+			bookmarkId8 = 북마크_링크_메타데이터_동시_등록(profileId2, "www.kakao.com", ALL);
 			bookmarkId7 = 북마크_링크_메타데이터_동시_등록(profileId2, "www.naver.com", ALL);
 
 			bookmarkId6 = 북마크_링크_메타데이터_동시_등록(profileId1, "www.github.com", PRIVATE);
-			bookmarkId5 = 북마크_링크_메타데이터_동시_등록(profileId1, "www.kakao.com", PARTIAL);
+			bookmarkId5 = 북마크_링크_메타데이터_동시_등록(profileId1, "www.kakao.com", ALL);
 			bookmarkId4 = 북마크_링크_메타데이터_동시_등록(profileId1, "www.naver.com", ALL);
 
 			팔로우(profileId1, profileId2);

--- a/src/test/java/com/meoguri/linkocean/domain/profile/query/persistence/ProfileQueryRepositoryTest.java
+++ b/src/test/java/com/meoguri/linkocean/domain/profile/query/persistence/ProfileQueryRepositoryTest.java
@@ -26,7 +26,7 @@ class ProfileQueryRepositoryTest extends BasePersistenceTest {
 		//given
 		final Profile profile = 사용자_프로필_동시_저장("user1@gmail.com", GOOGLE, "user1", IT);
 		final Bookmark bookmark1 = 북마크_링크_메타데이터_동시_저장(profile, "title1", ALL, IT, "www.naver.com");
-		final Bookmark bookmark2 = 북마크_링크_메타데이터_동시_저장(profile, "title2", PARTIAL, HOME, "www.google.com");
+		final Bookmark bookmark2 = 북마크_링크_메타데이터_동시_저장(profile, "title2", ALL, HOME, "www.google.com");
 		final Bookmark bookmark3 = 북마크_링크_메타데이터_동시_저장(profile, "title3", PRIVATE, IT, "www.github.com");
 
 		즐겨찾기_저장(profile, bookmark1);

--- a/src/test/java/com/meoguri/linkocean/test/restdocs/BookmarkRestDocsTest.java
+++ b/src/test/java/com/meoguri/linkocean/test/restdocs/BookmarkRestDocsTest.java
@@ -73,7 +73,7 @@ class BookmarkRestDocsTest extends RestDocsTestSupport {
 	@Test
 	void 내_북마크_목록_조회_api() throws Exception {
 		북마크_등록(링크_메타데이터_얻기("https://www.naver.com"), "title1", "IT", List.of("공부"), "all");
-		북마크_등록(링크_메타데이터_얻기("https://www.airbnb.co.kr"), "title2", "여행", List.of("travel"), "partial");
+		북마크_등록(링크_메타데이터_얻기("https://www.airbnb.co.kr"), "title2", "여행", List.of("travel"), "private");
 
 		//when
 		final ResultActions perform = mockMvc.perform(get(basePath + "/me")
@@ -125,7 +125,7 @@ class BookmarkRestDocsTest extends RestDocsTestSupport {
 		final long otherProfileId = 프로필_등록("user1", List.of("IT"));
 
 		북마크_등록(링크_메타데이터_얻기("https://www.naver.com"), "title1", "IT", List.of("공부"), "all");
-		북마크_등록(링크_메타데이터_얻기("https://www.airbnb.co.kr"), "title2", "여행", List.of("travel"), "partial");
+		북마크_등록(링크_메타데이터_얻기("https://www.airbnb.co.kr"), "title2", "여행", List.of("travel"), "all");
 		북마크_등록(링크_메타데이터_얻기("https://programmers.co.kr"), "title3", "기술", List.of("공부", "코테"), "private");
 		북마크_등록(링크_메타데이터_얻기("https://www.google.com"), "title4", "자기계발", List.of("머구리"), "all");
 
@@ -182,21 +182,21 @@ class BookmarkRestDocsTest extends RestDocsTestSupport {
 		프로필_등록("user3", List.of("IT"));
 
 		북마크_등록(링크_메타데이터_얻기("https://www.github.com"), "private");
-		북마크_등록(링크_메타데이터_얻기("https://www.google.com"), "partial");
+		북마크_등록(링크_메타데이터_얻기("https://www.google.com"), "all");
 		북마크_등록(링크_메타데이터_얻기("https://www.naver.com"), "all");
 
 		유저_등록_로그인("user2@gmail.com", GOOGLE);
 		final long profileId2 = 프로필_등록("user2", List.of("IT"));
 
 		북마크_등록(링크_메타데이터_얻기("https://www.github.com"), "private");
-		북마크_등록(링크_메타데이터_얻기("https://www.google.com"), "partial");
+		북마크_등록(링크_메타데이터_얻기("https://www.google.com"), "all");
 		북마크_등록(링크_메타데이터_얻기("https://www.naver.com"), "all");
 
 		유저_등록_로그인("user1@gmail.com", GOOGLE);
 		프로필_등록("user1", List.of("IT"));
 
 		북마크_등록(링크_메타데이터_얻기("https://www.github.com"), "private");
-		북마크_등록(링크_메타데이터_얻기("https://www.google.com"), "partial");
+		북마크_등록(링크_메타데이터_얻기("https://www.google.com"), "all");
 		북마크_등록(링크_메타데이터_얻기("https://www.naver.com"), "all");
 
 		팔로우(profileId2);


### PR DESCRIPTION
<!-- PR 제목 양식 예시: [LO-N] 회원 기능 도메인 -->

## 🛠️ 작업 내용
- 북마크 오픈타입 정책 변경

## 🗨️ 기타
<!-- PR 포인트 혹은 궁금한 점 등등 적어주시면 됩니다. 없으시면 지워주세요 -->
- 원래 북마크 오픈타입에는 ALL, PARTIAL, PRIVATE이 있었습니다. PARTIAL은 자신의 팔로워들에게만 북마크 접근을 허용하는 개념이었습니다. 하지만 저희 서비스는 팔로워, 팔로이 정책이기 때문에 아무나 나를 팔로우 할 수 있습니다. 따라서 PARTIAL이 의미가 없고, 오히려 비즈니스 로직만 복잡하게 만들었습니다. 그래서 저번에 팀 회의에서 제거하기로 결정했었습니다.

<hr/>

- 현재 피드 북마크 목록조회, 다른 사람 북마크 목록 조회, 내 북마크 목록 조회를 CustomBookmarkRepositoryImpl의 findBookmarks 메소드에서 해결하고 있습니다. 저희가 초반에는 querydsl의 동적쿼리를 최대한 이용하고, 중복 코드를 없애기 위해 통합했었습니다. 그런데 지금와서 보니까 유지보수 하기 어려운 코드 같다고 느꼈습니다. 북마크 목록 조회와, 피드 북마크 목록조회는 어떻게 보면 다른 기능이라고 생각합니다. 따라서 이를 분리하면 코드 중복이 생길지라도 유지보수와 확장성 측면에서는 더 좋아질 것 같다는 생각을 했습니다. 🤔 

## 😎 리뷰어
@ndy2 , @jk05018 
