### PR TITLE
[LO-224] 링크 메타데이터 동기화 버그 해결

### DIFF
--- a/src/main/java/com/meoguri/linkocean/domain/linkmetadata/service/LinkMetadataServiceImpl.java
+++ b/src/main/java/com/meoguri/linkocean/domain/linkmetadata/service/LinkMetadataServiceImpl.java
@@ -56,8 +56,8 @@ public class LinkMetadataServiceImpl implements LinkMetadataService {
 		try {
 			final GetLinkMetadataResult result = getLinkMetadata.getLinkMetadata(Link.toString(link.getLink()));
 			link.update(result.getTitle(), result.getImage());
-		} catch (IllegalArgumentException e) {
-			linkMetadataRepository.delete(link);
+		} catch (IllegalArgumentException ignored) {
+			log.info("%s가 유효하지 않습니다.", Link.toString(link.getLink()));
 		}
 	}
 }

--- a/src/test/java/com/meoguri/linkocean/domain/linkmetadata/service/LinkMetadataServiceImplTest.java
+++ b/src/test/java/com/meoguri/linkocean/domain/linkmetadata/service/LinkMetadataServiceImplTest.java
@@ -142,23 +142,24 @@ class LinkMetadataServiceImplTest extends BaseServiceTest {
 			() -> assertThat(originTitle3).isEqualTo(DEFAULT_TITLE)
 		);
 
-		링크_메타데이터_업데이트("https://www.naver.com", "네이버 채용", "naver-recruite.png");
+		final String updatedTitle1 = 링크_메타데이터_업데이트("https://www.naver.com", "네이버 채용", "naver-recruite.png");
 		링크_메타데이터_없어짐(crushUrl);
-		링크_메타데이터_업데이트("https://haha.com", "하하", "haha.png");
+		final String updatedTitle3 = 링크_메타데이터_업데이트("https://haha.com", "하하", "haha.png");
 
 		//when
 		linkMetadataService.synchronizeDataAndReturnNextPageable(createPageable());
 
 		//then
 		assertAll(
-			() -> assertThat(링크_제목_얻기("https://www.naver.com")).isEqualTo("네이버 채용"),
-			() -> assertThat(링크_제목_얻기(crushUrl)).isNull(),
-			() -> assertThat(링크_제목_얻기("https://haha.com")).isEqualTo("하하")
+			() -> assertThat(링크_제목_얻기("https://www.naver.com")).isEqualTo(updatedTitle1),
+			() -> assertThat(링크_제목_얻기(crushUrl)).isEqualTo(originTitle2),
+			() -> assertThat(링크_제목_얻기("https://haha.com")).isEqualTo(updatedTitle3)
 		);
 	}
 
-	private void 링크_메타데이터_업데이트(String url, String title, String image) {
+	private String 링크_메타데이터_업데이트(String url, String title, String image) {
 		given(getLinkMetadata.getLinkMetadata(url)).willReturn(new GetLinkMetadataResult(title, image));
+		return title;
 	}
 
 	private void 링크_메타데이터_없어짐(String url) {


### PR DESCRIPTION
<!-- PR 제목 양식 예시: [LO-N] 회원 기능 도메인 -->

## 🛠️ 작업 내용
- 링크 메타데이터 동기화 버그 해결

## 🗨️ 기타
<!-- PR 포인트 혹은 궁금한 점 등등 적어주시면 됩니다. 없으시면 지워주세요 -->
- 버그 이유
  - 기존 링크 메타데이터 동기화시, url이 유효하지 않으면 링크 메타데이터 데이터를 지워주는 정책으로 개발했습니다. 이때 발생하는 문제 중 하나가 기존 북마크에서 링크 메타데이터를 외래키고 갖고 있으면 북마크 데이터도 같이 변경해야 합니다.
- 동기화시 url이 유효하지 않은 경우 처리할 수 있는 선택지가 두 가지 있었습니다.
  -  링크 메타데이터 지우고, 북마크의 링크 메타데이터 외래키 null로 변경
     - 장점 : 데이터가 깔끔하게 지워짐
     - 단점 : 사용자 북마크에 있었던 이미지가 갑자기 없어지고, 추후 url이 유효하게 바뀌어도 북마크에 반영되지 않음 
  -  기존 값 유지
     - 장점 : 갑자기 이미지가 없어지지 않고, 추후 url이 유효하게 바뀌어도 동기화 시점에 북마크에 반영됨
     - 단점 : 데이터가 깔끔하게 지워지지 않음 
- 이미 존재했던 url이므로 지금은 유효하지 않더라도 추후에 유효해질 가능성이 있을 것 같고 사용자 입장에서는 갑자기 이미지가 없어지는 경험은 좋지 않을 것 같아 2번 방향으로 구현했습니다.

## 😎 리뷰어
@ndy2 , @jk05018 
