### PR TITLE
[LO-223] follow 에서 id 만 가지게 하기

### DIFF
--- a/src/main/java/com/meoguri/linkocean/domain/bookmark/persistence/CustomBookmarkRepositoryImpl.java
+++ b/src/main/java/com/meoguri/linkocean/domain/bookmark/persistence/CustomBookmarkRepositoryImpl.java
@@ -145,10 +145,10 @@ public class CustomBookmarkRepositoryImpl extends Querydsl4RepositorySupport imp
 	}
 
 	private BooleanBuilder followedBy(long currentUserProfileId) {
-		return nullSafeBuilder(() -> bookmark.writer.in(
-			select(follow.id.followee)
+		return nullSafeBuilder(() -> bookmark.writer.id.in(
+			select(follow.id.followeeId)
 				.from(follow)
-				.where(follow.id.follower.id.eq(currentUserProfileId))
+				.where(follow.id.followerId.eq(currentUserProfileId))
 		));
 	}
 

--- a/src/main/java/com/meoguri/linkocean/domain/profile/entity/Follow.java
+++ b/src/main/java/com/meoguri/linkocean/domain/profile/entity/Follow.java
@@ -5,11 +5,11 @@ import static lombok.AccessLevel.*;
 
 import java.io.Serializable;
 
+import javax.persistence.Column;
 import javax.persistence.Embeddable;
 import javax.persistence.EmbeddedId;
 import javax.persistence.Entity;
 import javax.persistence.JoinColumn;
-import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 
 import lombok.EqualsAndHashCode;
@@ -27,12 +27,12 @@ public class Follow {
 	@EmbeddedId
 	private FollowId id;
 
-	public Follow(final Profile follower, final Profile followee) {
-		this.id = new FollowId(follower, followee);
+	public Follow(final long followerId, final long followeeId) {
+		this.id = new FollowId(followerId, followeeId);
 	}
 
 	public boolean isFolloweeOf(final Profile profile) {
-		return id.getFollowee().equals(profile);
+		return id.getFolloweeId() == profile.getId();
 	}
 
 	@Getter
@@ -41,21 +41,19 @@ public class Follow {
 	@EqualsAndHashCode
 	static class FollowId implements Serializable {
 
-		@ManyToOne(optional = false)
+		@Column(nullable = false)
 		@JoinColumn(name = "follower_id")
-		private Profile follower;
+		private long followerId;
 
-		@ManyToOne(optional = false)
+		@Column(nullable = false)
 		@JoinColumn(name = "followee_id")
-		private Profile followee;
+		private long followeeId;
 
-		public FollowId(final Profile follower, final Profile followee) {
-			checkNotNull(follower);
-			checkNotNull(followee);
-			checkCondition(!follower.equals(followee), "자기 자신을 팔로우 할 수 없습니다");
+		public FollowId(final long followerId, final long followeeId) {
+			checkCondition(followerId != followeeId, "자기 자신을 팔로우 할 수 없습니다");
 
-			this.follower = follower;
-			this.followee = followee;
+			this.followerId = followerId;
+			this.followeeId = followeeId;
 		}
 	}
 }

--- a/src/main/java/com/meoguri/linkocean/domain/profile/entity/Profile.java
+++ b/src/main/java/com/meoguri/linkocean/domain/profile/entity/Profile.java
@@ -46,7 +46,7 @@ public class Profile extends BaseIdEntity {
 	@Embedded
 	private FavoriteBookmarkIds favoriteBookmarkIds = new FavoriteBookmarkIds();
 
-	@OneToMany(cascade = ALL, orphanRemoval = true, mappedBy = "id.follower")
+	@OneToMany(cascade = ALL, orphanRemoval = true, mappedBy = "id.followerId")
 	private Set<Follow> follows = new HashSet<>();
 
 	@Column(nullable = false, unique = true, length = MAX_PROFILE_USERNAME_LENGTH)
@@ -90,7 +90,7 @@ public class Profile extends BaseIdEntity {
 		checkCondition(!isFollow(target),
 			format("illegal follow command of profileId: %d on targetProfileId: %d", this.getId(), target.getId()));
 
-		this.follows.add(new Follow(this, target));
+		this.follows.add(new Follow(this.getId(), target.getId()));
 	}
 
 	/* 언팔로우 */
@@ -98,7 +98,7 @@ public class Profile extends BaseIdEntity {
 		checkCondition(isFollow(target),
 			format("illegal unfollow command of profileId: %d on targetProfileId: %d", this.getId(), target.getId()));
 
-		this.follows.remove(new Follow(this, target));
+		this.follows.remove(new Follow(this.getId(), target.getId()));
 	}
 
 	/* 프로필 팔로우 중인지 확인 */

--- a/src/main/java/com/meoguri/linkocean/domain/profile/query/persistence/CustomProfileQueryRepositoryImpl.java
+++ b/src/main/java/com/meoguri/linkocean/domain/profile/query/persistence/CustomProfileQueryRepositoryImpl.java
@@ -2,7 +2,6 @@ package com.meoguri.linkocean.domain.profile.query.persistence;
 
 import static com.meoguri.linkocean.domain.profile.entity.QFollow.*;
 import static com.meoguri.linkocean.domain.profile.entity.QProfile.*;
-import static com.meoguri.linkocean.support.domain.persistence.querydsl.JoinInfoBuilder.Initializer.*;
 
 import javax.persistence.EntityManager;
 
@@ -42,29 +41,22 @@ public class CustomProfileQueryRepositoryImpl extends Querydsl4RepositorySupport
 		);
 	}
 
-	private BooleanBuilder followerOfUsername(final Long profileId, final String username) {
-		return nullSafeBuilder(() -> profile.in(applyDynamicJoin(
-			select(follow.id.follower).from(follow),
-			joinIf(username != null,
-				() -> join(follow.id.follower, profile)
-					.on(follow.id.follower.id.eq(profile.id))))
-			.where(
-				follow.id.followee.id.eq(profileId),
-				usernameContains(username)
-			)
+	private BooleanBuilder followerOfUsername(final Long currentProfileId, final String username) {
+		return nullSafeBuilder(() -> profile.id.in(
+			select(follow.id.followerId)
+				.from(follow)
+				.where(
+					usernameContains(username),
+					follow.id.followeeId.eq(currentProfileId)
+				)
 		));
 	}
 
-	private BooleanBuilder followeeOfUsername(final Long profileId, final String username) {
-		return nullSafeBuilder(() -> profile.in(applyDynamicJoin(
-			select(follow.id.followee).from(follow),
-			joinIf(username != null,
-				() -> join(follow.id.followee, profile)
-					.on(follow.id.followee.id.eq(profile.id))))
-			.where(
-				follow.id.follower.id.eq(profileId),
-				usernameContains(username)
-			)
+	private BooleanBuilder followeeOfUsername(final Long currentProfileId, final String username) {
+		return nullSafeBuilder(() -> profile.id.in(
+			select(follow.id.followeeId)
+				.from(follow)
+				.where(usernameContains(username), follow.id.followerId.eq(currentProfileId))
 		));
 	}
 

--- a/src/main/java/com/meoguri/linkocean/domain/profile/query/persistence/CustomProfileQueryRepositoryImpl.java
+++ b/src/main/java/com/meoguri/linkocean/domain/profile/query/persistence/CustomProfileQueryRepositoryImpl.java
@@ -56,7 +56,10 @@ public class CustomProfileQueryRepositoryImpl extends Querydsl4RepositorySupport
 		return nullSafeBuilder(() -> profile.id.in(
 			select(follow.id.followeeId)
 				.from(follow)
-				.where(usernameContains(username), follow.id.followerId.eq(currentProfileId))
+				.where(
+					usernameContains(username),
+					follow.id.followerId.eq(currentProfileId)
+				)
 		));
 	}
 

--- a/src/main/java/com/meoguri/linkocean/domain/profile/query/persistence/ProfileQueryRepository.java
+++ b/src/main/java/com/meoguri/linkocean/domain/profile/query/persistence/ProfileQueryRepository.java
@@ -24,12 +24,12 @@ public interface ProfileQueryRepository extends JpaRepository<Profile, Long>, Cu
 	/* user 를 팔로우 하는 사용자의 카운트 */
 	@Query("select count(f) "
 		+ "from Follow f "
-		+ "where f.id.follower = :profile")
-	int getFolloweeCount(Profile profile);
+		+ "where f.id.followerId = :profileId")
+	int getFolloweeCount(long profileId);
 
 	/* user 가 팔로우 하는 사용자의 카운트 */
 	@Query("select count(f) "
 		+ "from Follow f "
-		+ "where f.id.followee = :profile")
-	int getFollowerCount(Profile profile);
+		+ "where f.id.followeeId = :profileId")
+	int getFollowerCount(long profileId);
 }

--- a/src/main/java/com/meoguri/linkocean/domain/profile/query/service/ProfileQueryServiceImpl.java
+++ b/src/main/java/com/meoguri/linkocean/domain/profile/query/service/ProfileQueryServiceImpl.java
@@ -38,8 +38,8 @@ public class ProfileQueryServiceImpl implements ProfileQueryService {
 
 		/* 추가 정보 조회 */
 		final boolean isFollow = profile.isFollow(target);
-		final int followerCount = profileQueryRepository.getFollowerCount(target);
-		final int followeeCount = profileQueryRepository.getFolloweeCount(target);
+		final int followerCount = profileQueryRepository.getFollowerCount(target.getId());
+		final int followeeCount = profileQueryRepository.getFolloweeCount(target.getId());
 
 		/* 결과 반환 */
 		return new GetDetailedProfileResult(

--- a/src/test/java/com/meoguri/linkocean/domain/profile/query/persistence/CustomProfileQueryRepositoryImplTest.java
+++ b/src/test/java/com/meoguri/linkocean/domain/profile/query/persistence/CustomProfileQueryRepositoryImplTest.java
@@ -81,7 +81,7 @@ class CustomProfileQueryRepositoryImplTest extends BasePersistenceTest {
 			.build();
 
 		//when
-		final Slice<Profile> followerSlice = customProfileQueryRepository.findProfiles(cond, pageable);
+		final Slice<Profile> followerSlice = pretty(() -> customProfileQueryRepository.findProfiles(cond, pageable));
 
 		//then
 		assertThat(followerSlice).containsExactly(profile1);
@@ -100,7 +100,7 @@ class CustomProfileQueryRepositoryImplTest extends BasePersistenceTest {
 		ProfileFindCond cond3 = ProfileFindCond.builder().profileId(profileId3).followee(true).build();
 
 		//when
-		final Slice<Profile> followeeSlice1 = customProfileQueryRepository.findProfiles(cond1, pageable);
+		final Slice<Profile> followeeSlice1 = pretty(() -> customProfileQueryRepository.findProfiles(cond1, pageable));
 		final Slice<Profile> followeeSlice2 = customProfileQueryRepository.findProfiles(cond2, pageable);
 		final Slice<Profile> followeeSlice3 = customProfileQueryRepository.findProfiles(cond3, pageable);
 
@@ -124,7 +124,7 @@ class CustomProfileQueryRepositoryImplTest extends BasePersistenceTest {
 			.build();
 
 		//when
-		final Slice<Profile> followerSlice = customProfileQueryRepository.findProfiles(cond, pageable);
+		final Slice<Profile> followerSlice = pretty(() -> customProfileQueryRepository.findProfiles(cond, pageable));
 
 		//then
 		assertThat(followerSlice).containsExactly(profile3);


### PR DESCRIPTION
## 🛠️ 작업 내용
- follow 에서 id 만 가지게 하기
- fixture monkey 를 테스트 해보고 있는데 프로필 생성에 팔로우가 필요하고 팔로우 생성에 프로필이 필요해서 stack overflow 가 발생하더라고요 fixture monkey 를 잘 쓰면 적절 하게 탐색하거나 null 을 바인딩 해주는 방법으로 해결 할 수는 있겠지만 저는 뉴비기도 하고 해서 
follow 에 profile 참조가 필요한가 살펴 보았는데 사용되는 곳이 없더라고요
그래서 id 만 가지도록 변경하였습니다.

- 변경 하면서 profile 조회의 joinIf 구문을 없앴습니다. 찬찬히 보니까 join 이 필요 없는 로직 이었어요 

