### PR TITLE
[LO-228] 소셜 로그인 API 스펙 변경

### DIFF
--- a/src/docs/asciidoc/api/Auth-API.adoc
+++ b/src/docs/asciidoc/api/Auth-API.adoc
@@ -5,4 +5,4 @@
 
 === 사용자 인증
 
-operation::/auth-rest-docs-test/사용자_인증_api/[snippets='http-request,path-parameters,request-parameters,http-response,response-fields']
+operation::/auth-rest-docs-test/사용자_인증_api/[snippets='http-request,path-parameters,request-fields,http-response,response-fields']

--- a/src/main/java/com/meoguri/linkocean/controller/user/AuthController.java
+++ b/src/main/java/com/meoguri/linkocean/controller/user/AuthController.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.meoguri.linkocean.controller.user.dto.AuthRequest;
@@ -27,7 +28,7 @@ public class AuthController {
 
 	private final OAuthAuthenticationService oAuthAuthenticationService;
 
-	//TODO: 프론트랑 통합하면 해당 API는 없어질 예정
+	/* 테스트용 API - 프론트 역할 */
 	@Deprecated
 	@GetMapping("/{oAuthType}/temp")
 	public ResponseEntity<Void> redirectToAuthorizationUri(
@@ -39,6 +40,17 @@ public class AuthController {
 		final HttpHeaders headers = new HttpHeaders();
 		headers.setLocation(URI.create(authorizationUri));
 		return new ResponseEntity<>(headers, PERMANENT_REDIRECT);
+	}
+
+	/* 테스트용 API - 프론트 역할 */
+	@Deprecated
+	@GetMapping("/{oAuthType}")
+	public Map<String, Object> authenticate(
+		@PathVariable("oAuthType") String oAuthType,
+		@RequestParam("code") String code
+	) {
+		final AuthRequest request = new AuthRequest(code, "https://localhost/api/v1/auth/google");
+		return authenticate(oAuthType, request);
 	}
 
 	@PostMapping("/{oAuthType}")

--- a/src/main/java/com/meoguri/linkocean/controller/user/AuthController.java
+++ b/src/main/java/com/meoguri/linkocean/controller/user/AuthController.java
@@ -1,7 +1,6 @@
 package com.meoguri.linkocean.controller.user;
 
 import static org.springframework.http.HttpStatus.*;
-import static org.springframework.web.bind.annotation.RequestMethod.*;
 
 import java.net.URI;
 import java.util.Map;
@@ -10,10 +9,12 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.meoguri.linkocean.controller.user.dto.AuthRequest;
 import com.meoguri.linkocean.domain.user.entity.vo.OAuthType;
 import com.meoguri.linkocean.domain.user.service.OAuthAuthenticationService;
 
@@ -40,13 +41,15 @@ public class AuthController {
 		return new ResponseEntity<>(headers, PERMANENT_REDIRECT);
 	}
 
-	//TODO: 프론트랑 통합하면 HTTP METHOD GET 제거하기
-	@RequestMapping(value = "/{oAuthType}", method = {GET, POST})
+	@PostMapping("/{oAuthType}")
 	public Map<String, Object> authenticate(
 		@PathVariable("oAuthType") String oAuthType,
-		@RequestParam("code") String code
+		@RequestBody AuthRequest authRequest
 	) {
-		final String jwt = oAuthAuthenticationService.authenticate(OAuthType.of(oAuthType.toUpperCase()), code);
+		final String jwt = oAuthAuthenticationService.authenticate(
+			OAuthType.of(oAuthType.toUpperCase()),
+			authRequest.getCode(),
+			authRequest.getRedirectUri());
 
 		return Map.of("token", jwt);
 	}

--- a/src/main/java/com/meoguri/linkocean/controller/user/dto/AuthRequest.java
+++ b/src/main/java/com/meoguri/linkocean/controller/user/dto/AuthRequest.java
@@ -1,0 +1,12 @@
+package com.meoguri.linkocean.controller.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public final class AuthRequest {
+
+	private String code;
+	private String redirectUri;
+}

--- a/src/main/java/com/meoguri/linkocean/domain/user/service/OAuthAuthenticationService.java
+++ b/src/main/java/com/meoguri/linkocean/domain/user/service/OAuthAuthenticationService.java
@@ -17,7 +17,7 @@ public class OAuthAuthenticationService {
 
 	private final UserService userService;
 
-	/* oAuthType에 맞는 소셜 로그인 uri를 반환한다. */
+	/* oAuthType에 맞는 소셜 로그인 uri를 반환한다.- 테스트용 */
 	@Deprecated
 	public String getAuthorizationUri(final OAuthType oAuthType) {
 

--- a/src/main/java/com/meoguri/linkocean/domain/user/service/OAuthAuthenticationService.java
+++ b/src/main/java/com/meoguri/linkocean/domain/user/service/OAuthAuthenticationService.java
@@ -35,14 +35,14 @@ public class OAuthAuthenticationService {
 	 * 3. DB에 사용자 정보 없으면 저장하기
 	 * 4. Jwt 토큰 발급 후 반환
 	 */
-	public String authenticate(final OAuthType oAuthType, final String authorizationCode) {
+	public String authenticate(final OAuthType oAuthType, final String authorizationCode, final String redirectUri) {
 
 		//TODO 벤더사 추가 쉽도록 확장성 있게 리팩토링하기, 아직 구글만 지원함.
 		if (oAuthType != OAuthType.GOOGLE) {
 			throw new IllegalArgumentException("구글 소셜 로그인만 지원되는 기능입니다.");
 		}
 
-		final String accessToken = oAuthClient.getAccessToken(authorizationCode);
+		final String accessToken = oAuthClient.getAccessToken(authorizationCode, redirectUri);
 		final Email email = oAuthClient.getUserEmail(accessToken);
 
 		userService.registerIfNotExists(email, oAuthType);

--- a/src/main/java/com/meoguri/linkocean/domain/user/service/OAuthClient.java
+++ b/src/main/java/com/meoguri/linkocean/domain/user/service/OAuthClient.java
@@ -9,7 +9,7 @@ public interface OAuthClient {
 	String getAuthorizationUri();
 
 	/* 인증 코드 이용해 access Token 얻어온다 */
-	String getAccessToken(String authorizationCode);
+	String getAccessToken(String authorizationCode, String redirectUri);
 
 	/* access token 이용해 사용자 이메일 정보를 얻어온다 */
 	Email getUserEmail(String accessToken);

--- a/src/main/java/com/meoguri/linkocean/infrastructure/oauth/google/GoogleOAuthClient.java
+++ b/src/main/java/com/meoguri/linkocean/infrastructure/oauth/google/GoogleOAuthClient.java
@@ -37,7 +37,7 @@ public class GoogleOAuthClient implements OAuthClient {
 			.queryParam("scope", googleOAuthProperties.getScope())
 			.queryParam("response_type", googleOAuthProperties.getResponseType())
 			.queryParam("client_id", googleOAuthProperties.getClientId())
-			.queryParam("redirect_uri", googleOAuthProperties.getRedirectUri())
+			.queryParam("redirect_uri", "https://localhost/api/v1/auth/google")
 			.build().encode().toString();
 		log.info("google authorization url : {}", authorizationUri);
 

--- a/src/main/java/com/meoguri/linkocean/infrastructure/oauth/google/GoogleOAuthClient.java
+++ b/src/main/java/com/meoguri/linkocean/infrastructure/oauth/google/GoogleOAuthClient.java
@@ -45,14 +45,14 @@ public class GoogleOAuthClient implements OAuthClient {
 	}
 
 	@Override
-	public String getAccessToken(final String authorizationCode) {
+	public String getAccessToken(final String authorizationCode, final String redirectUri) {
 
 		final HashMap<String, Object> params = new HashMap<>();
 		params.put("code", authorizationCode);
 		params.put("client_id", googleOAuthProperties.getClientId());
 		params.put("client_secret", googleOAuthProperties.getClientSecret());
 		params.put("grant_type", googleOAuthProperties.getGrantType());
-		params.put("redirect_uri", googleOAuthProperties.getRedirectUri());
+		params.put("redirect_uri", redirectUri);
 
 		final ResponseEntity<String> responseEntity = restTemplate.postForEntity(
 			googleOAuthProperties.getTokenUri(),

--- a/src/main/java/com/meoguri/linkocean/infrastructure/oauth/google/GoogleOAuthClient.java
+++ b/src/main/java/com/meoguri/linkocean/infrastructure/oauth/google/GoogleOAuthClient.java
@@ -30,6 +30,8 @@ public class GoogleOAuthClient implements OAuthClient {
 	private final RestTemplate restTemplate;
 	private final ObjectMapper objectMapper;
 
+	/* 테스트 용도 */
+	@Deprecated
 	@Override
 	public String getAuthorizationUri() {
 

--- a/src/main/java/com/meoguri/linkocean/infrastructure/oauth/google/GoogleOAuthProperties.java
+++ b/src/main/java/com/meoguri/linkocean/infrastructure/oauth/google/GoogleOAuthProperties.java
@@ -16,7 +16,6 @@ public class GoogleOAuthProperties {
 	private String clientSecret;
 	private String scope;
 	private String grantType;
-	private String redirectUri;
 	private String responseType;
 
 	private String authorizationUri;

--- a/src/test/java/com/meoguri/linkocean/controller/user/AuthControllerTest.java
+++ b/src/test/java/com/meoguri/linkocean/controller/user/AuthControllerTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.web.servlet.ResultActions;
 
+import com.meoguri.linkocean.controller.user.dto.AuthRequest;
 import com.meoguri.linkocean.domain.user.entity.vo.Email;
 import com.meoguri.linkocean.domain.user.service.OAuthClient;
 import com.meoguri.linkocean.exception.OAuthException;
@@ -26,11 +27,14 @@ class AuthControllerTest extends BaseControllerTest {
 	void 사용자_인증_api_성공() throws Exception {
 		//given
 		final String oAuthType = "google";
+		final AuthRequest request = new AuthRequest("code", "http://localhost/redirect");
+
 		given(oAuthClient.getUserEmail(any())).willReturn(new Email("email@google.com"));
 
 		//when
 		final ResultActions perform = mockMvc.perform(post(basePath + "/{oAuthType}", oAuthType)
-			.param("code", "code")
+			.contentType(APPLICATION_JSON)
+			.content(createJson(request))
 			.accept(APPLICATION_JSON));
 
 		//then
@@ -44,11 +48,14 @@ class AuthControllerTest extends BaseControllerTest {
 	void 사용자_인증_api_실패() throws Exception {
 		//given
 		final String oAuthType = "google";
+		final AuthRequest request = new AuthRequest("code", "http://localhost/redirect");
+
 		given(oAuthClient.getUserEmail(any())).willThrow(new OAuthException("OAuth 로그인에 실패했습니다."));
 
 		//when
 		final ResultActions perform = mockMvc.perform(post(basePath + "/{oAuthType}", oAuthType)
-			.param("code", "code")
+			.contentType(APPLICATION_JSON)
+			.content(createJson(request))
 			.accept(APPLICATION_JSON));
 
 		//then

--- a/src/test/java/com/meoguri/linkocean/domain/user/service/OAuthAuthenticationServiceTest.java
+++ b/src/test/java/com/meoguri/linkocean/domain/user/service/OAuthAuthenticationServiceTest.java
@@ -24,11 +24,12 @@ class OAuthAuthenticationServiceTest extends BaseServiceTest {
 	void 사용자_인증_성공() {
 		//given
 		final String authorizationCode = "code";
+		final String redirectUri = "http://localhost/redirectUri";
 
 		given(oAuthClient.getUserEmail(any())).willReturn(new Email("email@google.com"));
 
 		//when
-		final String jwt = oAuthAuthenticationService.authenticate(GOOGLE, authorizationCode);
+		final String jwt = oAuthAuthenticationService.authenticate(GOOGLE, authorizationCode, redirectUri);
 
 		//then
 		assertThat(jwt).isNotBlank();

--- a/src/test/java/com/meoguri/linkocean/infrastructure/oauth/google/GoogleOAuthClientTest.java
+++ b/src/test/java/com/meoguri/linkocean/infrastructure/oauth/google/GoogleOAuthClientTest.java
@@ -48,6 +48,8 @@ class GoogleOAuthClientTest {
 	void access_token_발급_요청_성공() throws JsonProcessingException {
 		//given
 		final String authorizationCode = "code";
+		final String redirectUri = "http://localhost/redirectUri";
+
 		final String accessToken = "access token";
 		final GoogleOAuthToken googleOAuthToken = new GoogleOAuthToken(
 			accessToken,
@@ -61,13 +63,13 @@ class GoogleOAuthClientTest {
 		params.put("client_id", googleOAuthProperties.getClientId());
 		params.put("client_secret", googleOAuthProperties.getClientSecret());
 		params.put("grant_type", googleOAuthProperties.getGrantType());
-		params.put("redirect_uri", googleOAuthProperties.getRedirectUri());
+		params.put("redirect_uri", redirectUri);
 
 		given(restTemplate.postForEntity(googleOAuthProperties.getTokenUri(), params, String.class))
 			.willReturn(ResponseEntity.ok(objectMapper.writeValueAsString(googleOAuthToken)));
 
 		//when
-		final String responseAccessToken = googleOAuthClient.getAccessToken(authorizationCode);
+		final String responseAccessToken = googleOAuthClient.getAccessToken(authorizationCode, redirectUri);
 
 		//then
 		assertThat(accessToken).isEqualTo(responseAccessToken);

--- a/src/test/java/com/meoguri/linkocean/test/restdocs/AuthRestDocsTest.java
+++ b/src/test/java/com/meoguri/linkocean/test/restdocs/AuthRestDocsTest.java
@@ -12,6 +12,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.web.servlet.ResultActions;
 
 import com.meoguri.linkocean.controller.user.AuthController;
+import com.meoguri.linkocean.controller.user.dto.AuthRequest;
 import com.meoguri.linkocean.domain.user.entity.vo.Email;
 import com.meoguri.linkocean.domain.user.service.OAuthClient;
 import com.meoguri.linkocean.test.restdocs.support.RestDocsTestSupport;
@@ -27,11 +28,14 @@ class AuthRestDocsTest extends RestDocsTestSupport {
 	void 사용자_인증_api() throws Exception {
 		//given
 		final String oAuthType = "google";
+		final AuthRequest request = new AuthRequest("code", "http://localhost/redirect");
+
 		given(oAuthClient.getUserEmail(any())).willReturn(new Email("email@google.com"));
 
 		//when
 		final ResultActions perform = mockMvc.perform(post(basePath + "/{oAuthType}", oAuthType)
-			.param("code", "code")
+			.contentType(APPLICATION_JSON)
+			.content(createJson(request))
 			.accept(APPLICATION_JSON));
 
 		//then
@@ -41,8 +45,9 @@ class AuthRestDocsTest extends RestDocsTestSupport {
 					pathParameters(
 						parameterWithName("oAuthType").description("소셜 로그인 타입")
 					),
-					requestParameters(
-						parameterWithName("code").description("서드 파티 인증 서버에게 받은 인증 코드")
+					requestFields(
+						fieldWithPath("code").description("인증 코드"),
+						fieldWithPath("redirectUri").description("REDIRECT URI")
 					),
 					responseFields(
 						fieldWithPath("token").description("jwt 토큰")


### PR DESCRIPTION
<!-- PR 제목 양식 예시: [LO-N] 회원 기능 도메인 -->

## 🛠️ 작업 내용
- 소셜 로그인 API 스펙 변경

## 🗨️ 기타
<!-- PR 포인트 혹은 궁금한 점 등등 적어주시면 됩니다. 없으시면 지워주세요 -->
- 인증 요청시 redirect uri 정보도 보내도록 API 스펙 변경했습니다.
  - 저희의 로그인 플로우상 redirect uri는 프론트에서 정합니다. 따라서 해당 정보도 인증 요청시 인증 코드와 같이 받는게 적절하다고 판단돼 API 스펙을 변경했습니다.

## 😎 리뷰어
@ndy2 , @jk05018 , @NewEgoDoc, @hyuk0309