### PR TITLE
[LO-232] 배포, 운영 CI-CD 수정

### DIFF
--- a/.github/workflows/dev-ci-cd.yml
+++ b/.github/workflows/dev-ci-cd.yml
@@ -69,7 +69,7 @@ jobs:
           port: 22
           script: |
             docker image prune -f
-            sudo docker rm -f $(docker ps -qa)
+            sudo docker rm -f linkocean-spring
             sudo docker pull ${{ secrets.DOCKER_REPO }}/linkocean_dev
             sudo docker run -d -p 443:443 --name linkocean-spring ${{ secrets.DOCKER_REPO }}/linkocean_dev
 

--- a/.github/workflows/prod-ci-cd.yml
+++ b/.github/workflows/prod-ci-cd.yml
@@ -69,7 +69,7 @@ jobs:
           port: 22
           script: |
             docker image prune -f
-            sudo docker rm -f $(docker ps -qa)
+            sudo docker rm -f linkocean-spring
             sudo docker pull ${{ secrets.DOCKER_REPO }}/linkocean_prod
             sudo docker run -d -p 8080:8080 --name linkocean-spring ${{ secrets.DOCKER_REPO }}/linkocean_prod
 


### PR DESCRIPTION
<!-- PR 제목 양식 예시: [LO-N] 회원 기능 도메인 -->

## 🛠️ 작업 내용
- 배포, 운영 CI-CD 수정

## 🗨️ 기타
<!-- PR 포인트 혹은 궁금한 점 등등 적어주시면 됩니다. 없으시면 지워주세요 -->
- CI-CD 프로세스에서 `docker remove -f $(docker ps -aq)`를 `docker remove -f linkocean-spring`로 수정했습니다. 왜냐하면 개발, 운영 서버에 redis도 실행되고 있기 때문입니다.

## 😎 리뷰어
@ndy2
