### PR TITLE
[LO-231] access token 재발급 API 개발

### DIFF
--- a/src/docs/asciidoc/api/Auth-API.adoc
+++ b/src/docs/asciidoc/api/Auth-API.adoc
@@ -6,3 +6,8 @@
 === 사용자 인증
 
 operation::/auth-rest-docs-test/사용자_인증_api/[snippets='http-request,path-parameters,request-fields,http-response,response-fields']
+
+
+=== access token 재발급
+
+operation::/auth-rest-docs-test/access_token_재발급_api/[snippets='http-request,request-fields,http-response,response-fields']

--- a/src/main/java/com/meoguri/linkocean/configuration/security/jwt/JwtProperties.java
+++ b/src/main/java/com/meoguri/linkocean/configuration/security/jwt/JwtProperties.java
@@ -13,5 +13,6 @@ import lombok.Setter;
 public class JwtProperties {
 
 	private String secretKey;
-	private long expiration;
+	private long accessTokenExpiration;
+	private long refreshTokenExpiration;
 }

--- a/src/main/java/com/meoguri/linkocean/configuration/security/jwt/JwtProvider.java
+++ b/src/main/java/com/meoguri/linkocean/configuration/security/jwt/JwtProvider.java
@@ -62,7 +62,7 @@ public class JwtProvider {
 				.parseClaimsJws(token)
 				.getBody();
 		} catch (IllegalArgumentException e) {
-			throw new JwtException("the claimsJws string is null or empty or only whitespace");
+			throw new JwtException("the claimsJws string is null or empty or only whitespace", e);
 		}
 	}
 

--- a/src/main/java/com/meoguri/linkocean/configuration/security/jwt/JwtProvider.java
+++ b/src/main/java/com/meoguri/linkocean/configuration/security/jwt/JwtProvider.java
@@ -5,17 +5,13 @@ import java.util.function.Function;
 
 import org.springframework.stereotype.Component;
 
-import com.meoguri.linkocean.exception.LinkoceanRuntimeException;
 import com.meoguri.linkocean.internal.user.domain.model.Email;
 import com.meoguri.linkocean.internal.user.domain.model.OAuthType;
 
 import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.MalformedJwtException;
 import io.jsonwebtoken.SignatureAlgorithm;
-import io.jsonwebtoken.SignatureException;
-import io.jsonwebtoken.UnsupportedJwtException;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
@@ -66,17 +62,8 @@ public class JwtProvider {
 				.setSigningKey(secretKey)
 				.parseClaimsJws(token)
 				.getBody();
-		} catch (UnsupportedJwtException e) {
-			throw new LinkoceanRuntimeException("the claimsJws argument does not represent an Claims JWS", e);
-		} catch (MalformedJwtException e) {
-			throw new LinkoceanRuntimeException("the claimsJws string is not a valid JWS", e);
-		} catch (SignatureException e) {
-			throw new LinkoceanRuntimeException("the claimsJws JWS signature validation fails", e);
-		} catch (ExpiredJwtException e) {
-			throw new LinkoceanRuntimeException("the specified JWT is a Claims JWT and the Claims "
-				+ "has an expiration time before the time this method is invoked.", e);
 		} catch (IllegalArgumentException e) {
-			throw new LinkoceanRuntimeException("the claimsJws string is null or empty or only whitespace", e);
+			throw new JwtException("the claimsJws string is null or empty or only whitespace");
 		}
 	}
 

--- a/src/main/java/com/meoguri/linkocean/configuration/security/jwt/JwtProvider.java
+++ b/src/main/java/com/meoguri/linkocean/configuration/security/jwt/JwtProvider.java
@@ -22,7 +22,7 @@ public class JwtProvider {
 
 	public String generateAccessToken(final Email email, final OAuthType oauthType) {
 		final Date now = new Date();
-		final Date expiration = new Date(now.getTime() + jwtProperties.getExpiration());
+		final Date expiration = new Date(now.getTime() + jwtProperties.getAccessTokenExpiration());
 
 		return Jwts.builder()
 			.setSubject("LinkOcean API Token")
@@ -37,8 +37,7 @@ public class JwtProvider {
 
 	public String generateRefreshToken(final Long userId) {
 		final Date now = new Date();
-		//TODO : access token과 refresh token 만료일 다르게 설정하기 (/refresh API 만들면서 진행할 것)
-		final Date expiration = new Date(now.getTime() + jwtProperties.getExpiration());
+		final Date expiration = new Date(now.getTime() + jwtProperties.getRefreshTokenExpiration());
 
 		return Jwts.builder()
 			.setSubject("LinkOcean Refresh Token")
@@ -68,6 +67,6 @@ public class JwtProvider {
 	}
 
 	public long getRefreshTokenExpiration() {
-		return jwtProperties.getExpiration();
+		return jwtProperties.getRefreshTokenExpiration();
 	}
 }

--- a/src/main/java/com/meoguri/linkocean/controller/CustomRestControllerAdvice.java
+++ b/src/main/java/com/meoguri/linkocean/controller/CustomRestControllerAdvice.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import com.meoguri.linkocean.exception.OAuthException;
 
+import io.jsonwebtoken.JwtException;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -42,6 +43,14 @@ public class CustomRestControllerAdvice {
 		log.info(ex.getMessage(), ex);
 
 		return ErrorResponse.of(BAD_REQUEST, "잘못된 요청입니다.", isProd, ex);
+	}
+
+	@ResponseStatus(UNAUTHORIZED)
+	@ExceptionHandler(JwtException.class)
+	public ErrorResponse handleJwtException(final JwtException ex) {
+		log.info(ex.getMessage(), ex);
+
+		return ErrorResponse.of(UNAUTHORIZED, "인증에 실패했습니다.", isProd, ex);
 	}
 
 	@ResponseStatus(INTERNAL_SERVER_ERROR)

--- a/src/main/java/com/meoguri/linkocean/controller/user/AuthController.java
+++ b/src/main/java/com/meoguri/linkocean/controller/user/AuthController.java
@@ -74,7 +74,7 @@ public class AuthController {
 			BEARER);
 	}
 
-	@PostMapping("/refresh")
+	@PostMapping("/token/refresh")
 	public AuthResponse refreshAccessToken(@RequestBody RefreshAccessTokenRequest request) {
 		if (!request.getTokenType().equals(BEARER)) {
 			throw new JwtException("잘못된 토큰 타입 입니다.");

--- a/src/main/java/com/meoguri/linkocean/controller/user/AuthController.java
+++ b/src/main/java/com/meoguri/linkocean/controller/user/AuthController.java
@@ -22,15 +22,12 @@ import com.meoguri.linkocean.internal.user.application.dto.AuthUserCommand;
 import com.meoguri.linkocean.internal.user.application.dto.GetAuthTokenResult;
 import com.meoguri.linkocean.internal.user.domain.model.OAuthType;
 
-import io.jsonwebtoken.JwtException;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/auth")
 @RestController
 public class AuthController {
-
-	private static final String BEARER = "Bearer";
 
 	private final OAuthAuthenticationService oAuthAuthenticationService;
 
@@ -71,21 +68,17 @@ public class AuthController {
 		return new AuthResponse(
 			getAuthTokenResult.getAccessToken(),
 			getAuthTokenResult.getRefreshToken(),
-			BEARER);
+			getAuthTokenResult.getTokenType());
 	}
 
 	@PostMapping("/token/refresh")
 	public AuthResponse refreshAccessToken(@RequestBody RefreshAccessTokenRequest request) {
-		if (!request.getTokenType().equals(BEARER)) {
-			throw new JwtException("잘못된 토큰 타입 입니다.");
-		}
-
 		final GetAuthTokenResult getAuthTokenResult = oAuthAuthenticationService.refreshAccessToken(
-			request.getRefreshToken());
+			request.getRefreshToken(), request.getTokenType());
 
 		return new AuthResponse(
 			getAuthTokenResult.getAccessToken(),
 			getAuthTokenResult.getRefreshToken(),
-			BEARER);
+			getAuthTokenResult.getTokenType());
 	}
 }

--- a/src/main/java/com/meoguri/linkocean/controller/user/AuthController.java
+++ b/src/main/java/com/meoguri/linkocean/controller/user/AuthController.java
@@ -16,17 +16,21 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.meoguri.linkocean.controller.user.dto.AuthRequest;
 import com.meoguri.linkocean.controller.user.dto.AuthResponse;
+import com.meoguri.linkocean.controller.user.dto.RefreshAccessTokenRequest;
 import com.meoguri.linkocean.internal.user.application.OAuthAuthenticationService;
 import com.meoguri.linkocean.internal.user.application.dto.AuthUserCommand;
 import com.meoguri.linkocean.internal.user.application.dto.GetAuthTokenResult;
 import com.meoguri.linkocean.internal.user.domain.model.OAuthType;
 
+import io.jsonwebtoken.JwtException;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/auth")
 @RestController
 public class AuthController {
+
+	private static final String BEARER = "Bearer";
 
 	private final OAuthAuthenticationService oAuthAuthenticationService;
 
@@ -67,6 +71,21 @@ public class AuthController {
 		return new AuthResponse(
 			getAuthTokenResult.getAccessToken(),
 			getAuthTokenResult.getRefreshToken(),
-			"Bearer");
+			BEARER);
+	}
+
+	@PostMapping("/refresh")
+	public AuthResponse refreshAccessToken(@RequestBody RefreshAccessTokenRequest request) {
+		if (!request.getTokenType().equals(BEARER)) {
+			throw new JwtException("잘못된 토큰 타입 입니다.");
+		}
+
+		final GetAuthTokenResult getAuthTokenResult = oAuthAuthenticationService.refreshAccessToken(
+			request.getRefreshToken());
+
+		return new AuthResponse(
+			getAuthTokenResult.getAccessToken(),
+			getAuthTokenResult.getRefreshToken(),
+			BEARER);
 	}
 }

--- a/src/main/java/com/meoguri/linkocean/controller/user/dto/RefreshAccessTokenRequest.java
+++ b/src/main/java/com/meoguri/linkocean/controller/user/dto/RefreshAccessTokenRequest.java
@@ -1,0 +1,12 @@
+package com.meoguri.linkocean.controller.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public final class RefreshAccessTokenRequest {
+
+	private String refreshToken;
+	private String tokenType;
+}

--- a/src/main/java/com/meoguri/linkocean/internal/user/application/OAuthAuthenticationService.java
+++ b/src/main/java/com/meoguri/linkocean/internal/user/application/OAuthAuthenticationService.java
@@ -18,6 +18,8 @@ import lombok.RequiredArgsConstructor;
 @Service
 public class OAuthAuthenticationService {
 
+	private static final String BEARER = "Bearer";
+
 	private final OAuthClient oAuthClient;
 	private final JwtProvider jwtProvider;
 
@@ -53,7 +55,7 @@ public class OAuthAuthenticationService {
 			jwtProvider.getRefreshTokenExpiration()
 		));
 
-		return new GetAuthTokenResult(linkoceanAccessToken, linkoceanRefreshToken);
+		return new GetAuthTokenResult(linkoceanAccessToken, linkoceanRefreshToken, BEARER);
 	}
 
 	/**
@@ -62,7 +64,10 @@ public class OAuthAuthenticationService {
 	 * 2. refresh token이 redis에 저장된 refresh token과 동일한지 검증
 	 * 3. 새로운 access token, refresh token 발급
 	 */
-	public GetAuthTokenResult refreshAccessToken(final String refreshToken) {
+	public GetAuthTokenResult refreshAccessToken(final String refreshToken, final String tokenType) {
+		if (!tokenType.equals("Bearer")) {
+			throw new JwtException("잘못된 토큰 타입 입니다.");
+		}
 
 		final Long userId = Long.valueOf(jwtProvider.getClaims(refreshToken, Claims::getId));
 
@@ -84,6 +89,6 @@ public class OAuthAuthenticationService {
 			jwtProvider.getRefreshTokenExpiration()
 		));
 
-		return new GetAuthTokenResult(newAccessToken, newRefreshToken);
+		return new GetAuthTokenResult(newAccessToken, newRefreshToken, BEARER);
 	}
 }

--- a/src/main/java/com/meoguri/linkocean/internal/user/application/OAuthAuthenticationService.java
+++ b/src/main/java/com/meoguri/linkocean/internal/user/application/OAuthAuthenticationService.java
@@ -70,7 +70,7 @@ public class OAuthAuthenticationService {
 			refreshTokenService.validateRefreshToken(userId, refreshToken);
 		} catch (JwtException ex) {
 			refreshTokenService.removeRefreshToken(userId);
-			throw new JwtException("인증 실패");
+			throw new JwtException("인증 실패", ex);
 		}
 
 		/* access token, refresh token 재발급 */

--- a/src/main/java/com/meoguri/linkocean/internal/user/application/RefreshTokenService.java
+++ b/src/main/java/com/meoguri/linkocean/internal/user/application/RefreshTokenService.java
@@ -8,6 +8,12 @@ public interface RefreshTokenService {
 	void registerRefreshToken(RegisterRefreshTokenCommand command);
 
 	/* 최신 refresh token인지 검증 */
+
+	/**
+	 * 유효한 refresh token인지 검증
+	 *
+	 * @throws io.jsonwebtoken.JwtException 검증 실패
+	 */
 	void validateRefreshToken(Long userId, String refreshToken);
 
 	/* refresh token 제거 */

--- a/src/main/java/com/meoguri/linkocean/internal/user/application/RefreshTokenService.java
+++ b/src/main/java/com/meoguri/linkocean/internal/user/application/RefreshTokenService.java
@@ -6,4 +6,10 @@ public interface RefreshTokenService {
 
 	/* refresh token 등록 */
 	void registerRefreshToken(RegisterRefreshTokenCommand command);
+
+	/* 최신 refresh token인지 검증 */
+	void validateRefreshToken(Long userId, String refreshToken);
+
+	/* refresh token 제거 */
+	void removeRefreshToken(Long userId);
 }

--- a/src/main/java/com/meoguri/linkocean/internal/user/application/dto/GetAuthTokenResult.java
+++ b/src/main/java/com/meoguri/linkocean/internal/user/application/dto/GetAuthTokenResult.java
@@ -8,4 +8,5 @@ import lombok.RequiredArgsConstructor;
 public final class GetAuthTokenResult {
 	private final String accessToken;
 	private final String refreshToken;
+	private final String tokenType;
 }

--- a/src/main/java/com/meoguri/linkocean/internal/user/domain/UserService.java
+++ b/src/main/java/com/meoguri/linkocean/internal/user/domain/UserService.java
@@ -4,11 +4,15 @@ import com.meoguri.linkocean.internal.profile.entity.Profile;
 import com.meoguri.linkocean.internal.user.domain.dto.GetUserResult;
 import com.meoguri.linkocean.internal.user.domain.model.Email;
 import com.meoguri.linkocean.internal.user.domain.model.OAuthType;
+import com.meoguri.linkocean.internal.user.domain.model.User;
 
 public interface UserService {
 
 	/* 사용자 조회 */
 	GetUserResult getUser(Email email, OAuthType oAuthType);
+
+	/* 사용자 조회 */
+	User getUser(long userId);
 
 	/* 사용자 없으면 등록 */
 	long registerIfNotExists(Email email, OAuthType oAuthType);

--- a/src/main/java/com/meoguri/linkocean/internal/user/domain/UserServiceImpl.java
+++ b/src/main/java/com/meoguri/linkocean/internal/user/domain/UserServiceImpl.java
@@ -36,6 +36,11 @@ public class UserServiceImpl implements UserService {
 		);
 	}
 
+	@Override
+	public User getUser(final long userId) {
+		return userRepository.findById(userId).orElseThrow(() -> new LinkoceanRuntimeException("존재하지 않는 사용자 아이디입니다."));
+	}
+
 	@Transactional
 	@Override
 	public long registerIfNotExists(final Email email, final OAuthType oAuthType) {

--- a/src/main/java/com/meoguri/linkocean/internal/user/infrastructure/redis/RedisRefreshTokenService.java
+++ b/src/main/java/com/meoguri/linkocean/internal/user/infrastructure/redis/RedisRefreshTokenService.java
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Service;
 import com.meoguri.linkocean.internal.user.application.RefreshTokenService;
 import com.meoguri.linkocean.internal.user.application.dto.RegisterRefreshTokenCommand;
 
+import io.jsonwebtoken.JwtException;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
@@ -21,5 +22,18 @@ public class RedisRefreshTokenService implements RefreshTokenService {
 			command.getExpiration());
 
 		redisRefreshTokenRepository.save(token);
+	}
+
+	@Override
+	public void validateRefreshToken(final Long userId, final String refreshToken) {
+		final RefreshToken token = redisRefreshTokenRepository.findById(userId)
+			.orElseThrow(() -> new JwtException("존재하지 않는 refresh token 입니다."));
+
+		token.isSameRefreshToken(refreshToken);
+	}
+
+	@Override
+	public void removeRefreshToken(final Long userId) {
+		redisRefreshTokenRepository.deleteById(userId);
 	}
 }

--- a/src/main/java/com/meoguri/linkocean/internal/user/infrastructure/redis/RedisRefreshTokenService.java
+++ b/src/main/java/com/meoguri/linkocean/internal/user/infrastructure/redis/RedisRefreshTokenService.java
@@ -29,7 +29,7 @@ public class RedisRefreshTokenService implements RefreshTokenService {
 		final RefreshToken token = redisRefreshTokenRepository.findById(userId)
 			.orElseThrow(() -> new JwtException("존재하지 않는 refresh token 입니다."));
 
-		token.isSameRefreshToken(refreshToken);
+		token.validateRefreshToken(refreshToken);
 	}
 
 	@Override

--- a/src/main/java/com/meoguri/linkocean/internal/user/infrastructure/redis/RefreshToken.java
+++ b/src/main/java/com/meoguri/linkocean/internal/user/infrastructure/redis/RefreshToken.java
@@ -7,6 +7,7 @@ import org.springframework.data.annotation.Id;
 import org.springframework.data.redis.core.RedisHash;
 import org.springframework.data.redis.core.TimeToLive;
 
+import io.jsonwebtoken.JwtException;
 import lombok.Getter;
 
 @Getter
@@ -29,5 +30,11 @@ public class RefreshToken {
 		this.userId = userId;
 		this.value = value;
 		this.expiration = expiration;
+	}
+
+	public void isSameRefreshToken(final String refreshToken) {
+		if (!value.equals(refreshToken)) {
+			throw new JwtException("만료된 refresh token 입니다.");
+		}
 	}
 }

--- a/src/main/java/com/meoguri/linkocean/internal/user/infrastructure/redis/RefreshToken.java
+++ b/src/main/java/com/meoguri/linkocean/internal/user/infrastructure/redis/RefreshToken.java
@@ -32,9 +32,9 @@ public class RefreshToken {
 		this.expiration = expiration;
 	}
 
-	public void isSameRefreshToken(final String refreshToken) {
+	public void validateRefreshToken(final String refreshToken) {
 		if (!value.equals(refreshToken)) {
-			throw new JwtException("만료된 refresh token 입니다.");
+			throw new JwtException("refresh token이 유효하지 않습니다.");
 		}
 	}
 }

--- a/src/test/java/com/meoguri/linkocean/configuration/security/jwt/JwtProviderTest.java
+++ b/src/test/java/com/meoguri/linkocean/configuration/security/jwt/JwtProviderTest.java
@@ -59,7 +59,8 @@ class JwtProviderTest {
 		public JwtProperties jwtProperties() {
 			final JwtProperties properties = new JwtProperties();
 			properties.setSecretKey("test secretKey");
-			properties.setExpiration(10000L);
+			properties.setAccessTokenExpiration(10000L);
+			properties.setRefreshTokenExpiration(100000L);
 			return properties;
 		}
 

--- a/src/test/java/com/meoguri/linkocean/controller/user/AuthControllerTest.java
+++ b/src/test/java/com/meoguri/linkocean/controller/user/AuthControllerTest.java
@@ -1,5 +1,6 @@
 package com.meoguri.linkocean.controller.user;
 
+import static com.meoguri.linkocean.internal.user.domain.model.OAuthType.*;
 import static org.mockito.BDDMockito.*;
 import static org.springframework.http.MediaType.*;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
@@ -7,21 +8,18 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.web.servlet.ResultActions;
 
 import com.meoguri.linkocean.controller.user.dto.AuthRequest;
+import com.meoguri.linkocean.controller.user.dto.AuthResponse;
+import com.meoguri.linkocean.controller.user.dto.RefreshAccessTokenRequest;
 import com.meoguri.linkocean.exception.OAuthException;
-import com.meoguri.linkocean.internal.user.application.OAuthClient;
 import com.meoguri.linkocean.internal.user.domain.model.Email;
 import com.meoguri.linkocean.test.support.controller.BaseControllerTest;
 
 class AuthControllerTest extends BaseControllerTest {
 
 	private final String basePath = getBaseUrl(AuthController.class);
-
-	@MockBean
-	private OAuthClient oAuthClient;
 
 	@Test
 	void 사용자_인증_api_성공() throws Exception {
@@ -64,5 +62,45 @@ class AuthControllerTest extends BaseControllerTest {
 		perform
 			.andExpect(status().is5xxServerError())
 			.andDo(print());
+	}
+
+	@Test
+	void access_token_재발급_성공() throws Exception {
+		//given
+		final AuthResponse authResponse = 로그인(GOOGLE, "code", "http://localhost/redirect");
+		final RefreshAccessTokenRequest request = new RefreshAccessTokenRequest(
+			authResponse.getRefreshToken(),
+			authResponse.getTokenType());
+
+		//when
+		final ResultActions perform = mockMvc.perform(post(basePath + "/refresh")
+			.contentType(APPLICATION_JSON)
+			.content(createJson(request))
+			.accept(APPLICATION_JSON));
+
+		//then
+		perform
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.accessToken").exists())
+			.andExpect(jsonPath("$.refreshToken").exists())
+			.andExpect(jsonPath("$.tokenType").value("Bearer"))
+			.andDo(print());
+	}
+
+	@Test
+	void access_token_재발급_실패_유효하지_않은_refresh_token() throws Exception {
+		//given
+		final String invalidRefreshToken = "invalidRefreshToken";
+		final RefreshAccessTokenRequest request = new RefreshAccessTokenRequest(invalidRefreshToken, "Bearer");
+
+		//when
+		final ResultActions perform = mockMvc.perform(post(basePath + "/refresh")
+			.contentType(APPLICATION_JSON)
+			.content(createJson(request))
+			.accept(APPLICATION_JSON));
+
+		//then
+		perform
+			.andExpect(status().isUnauthorized());
 	}
 }

--- a/src/test/java/com/meoguri/linkocean/controller/user/AuthControllerTest.java
+++ b/src/test/java/com/meoguri/linkocean/controller/user/AuthControllerTest.java
@@ -73,7 +73,7 @@ class AuthControllerTest extends BaseControllerTest {
 			authResponse.getTokenType());
 
 		//when
-		final ResultActions perform = mockMvc.perform(post(basePath + "/refresh")
+		final ResultActions perform = mockMvc.perform(post(basePath + "/token/refresh")
 			.contentType(APPLICATION_JSON)
 			.content(createJson(request))
 			.accept(APPLICATION_JSON));
@@ -94,7 +94,7 @@ class AuthControllerTest extends BaseControllerTest {
 		final RefreshAccessTokenRequest request = new RefreshAccessTokenRequest(invalidRefreshToken, "Bearer");
 
 		//when
-		final ResultActions perform = mockMvc.perform(post(basePath + "/refresh")
+		final ResultActions perform = mockMvc.perform(post(basePath + "/token/refresh")
 			.contentType(APPLICATION_JSON)
 			.content(createJson(request))
 			.accept(APPLICATION_JSON));

--- a/src/test/java/com/meoguri/linkocean/internal/user/application/OAuthAuthenticationServiceTest.java
+++ b/src/test/java/com/meoguri/linkocean/internal/user/application/OAuthAuthenticationServiceTest.java
@@ -55,7 +55,8 @@ class OAuthAuthenticationServiceTest extends BaseServiceTest {
 
 		//when
 		final GetAuthTokenResult result = oAuthAuthenticationService.refreshAccessToken(
-			getAuthTokenResult.getRefreshToken());
+			getAuthTokenResult.getRefreshToken(),
+			"Bearer");
 
 		//then
 		assertAll(
@@ -76,6 +77,6 @@ class OAuthAuthenticationServiceTest extends BaseServiceTest {
 
 		//when then
 		assertThatExceptionOfType(JwtException.class)
-			.isThrownBy(() -> oAuthAuthenticationService.refreshAccessToken(invalidRefreshToken));
+			.isThrownBy(() -> oAuthAuthenticationService.refreshAccessToken(invalidRefreshToken, "Bearer"));
 	}
 }

--- a/src/test/java/com/meoguri/linkocean/internal/user/domain/UserServiceImplTest.java
+++ b/src/test/java/com/meoguri/linkocean/internal/user/domain/UserServiceImplTest.java
@@ -2,6 +2,7 @@ package com.meoguri.linkocean.internal.user.domain;
 
 import static com.meoguri.linkocean.internal.bookmark.entity.vo.Category.*;
 import static com.meoguri.linkocean.internal.user.domain.model.OAuthType.*;
+import static com.meoguri.linkocean.test.support.common.Assertions.*;
 import static java.util.stream.Collectors.*;
 import static org.assertj.core.api.Assertions.*;
 
@@ -10,7 +11,6 @@ import java.util.Arrays;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import com.meoguri.linkocean.exception.LinkoceanRuntimeException;
 import com.meoguri.linkocean.internal.bookmark.entity.vo.Category;
 import com.meoguri.linkocean.internal.profile.command.persistence.ProfileRepository;
 import com.meoguri.linkocean.internal.profile.entity.FavoriteCategories;
@@ -62,7 +62,7 @@ class UserServiceImplTest extends BaseServiceTest {
 		final long invalidUserId = -1L;
 
 		//when then
-		assertThatExceptionOfType(LinkoceanRuntimeException.class)
+		assertThatLinkoceanRuntimeException()
 			.isThrownBy(() -> userService.getUser(invalidUserId));
 	}
 

--- a/src/test/java/com/meoguri/linkocean/internal/user/domain/UserServiceImplTest.java
+++ b/src/test/java/com/meoguri/linkocean/internal/user/domain/UserServiceImplTest.java
@@ -10,6 +10,7 @@ import java.util.Arrays;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import com.meoguri.linkocean.exception.LinkoceanRuntimeException;
 import com.meoguri.linkocean.internal.bookmark.entity.vo.Category;
 import com.meoguri.linkocean.internal.profile.command.persistence.ProfileRepository;
 import com.meoguri.linkocean.internal.profile.entity.FavoriteCategories;
@@ -17,6 +18,7 @@ import com.meoguri.linkocean.internal.profile.entity.Profile;
 import com.meoguri.linkocean.internal.user.domain.dto.GetUserResult;
 import com.meoguri.linkocean.internal.user.domain.model.Email;
 import com.meoguri.linkocean.internal.user.domain.model.OAuthType;
+import com.meoguri.linkocean.internal.user.domain.model.User;
 import com.meoguri.linkocean.test.support.internal.service.BaseServiceTest;
 
 class UserServiceImplTest extends BaseServiceTest {
@@ -40,6 +42,28 @@ class UserServiceImplTest extends BaseServiceTest {
 		assertThat(result.getProfileId()).isNull();
 		assertThat(result.getEmail()).isEqualTo(new Email("haha@gmail.com"));
 		assertThat(result.getOauthType()).isEqualTo(GOOGLE);
+	}
+
+	@Test
+	void 사용자_아이디로_사용자_조회_성공() {
+		//given
+		final long userId = 사용자_없으면_등록("crush@gmail.com", GOOGLE);
+
+		//when
+		final User user = userService.getUser(userId);
+
+		//then
+		assertThat(user).isNotNull();
+	}
+
+	@Test
+	void 사용자_아이디로_사용자_조회_실패() {
+		//given
+		final long invalidUserId = -1L;
+
+		//when then
+		assertThatExceptionOfType(LinkoceanRuntimeException.class)
+			.isThrownBy(() -> userService.getUser(invalidUserId));
 	}
 
 	@Test

--- a/src/test/java/com/meoguri/linkocean/internal/user/infrastructure/redis/RedisRefreshTokenServiceTest.java
+++ b/src/test/java/com/meoguri/linkocean/internal/user/infrastructure/redis/RedisRefreshTokenServiceTest.java
@@ -1,6 +1,7 @@
 package com.meoguri.linkocean.internal.user.infrastructure.redis;
 
 import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -10,6 +11,8 @@ import org.springframework.context.annotation.Import;
 
 import com.meoguri.linkocean.internal.user.application.RefreshTokenService;
 import com.meoguri.linkocean.internal.user.application.dto.RegisterRefreshTokenCommand;
+
+import io.jsonwebtoken.JwtException;
 
 @DataRedisTest
 @Import(RedisRefreshTokenService.class)
@@ -37,5 +40,72 @@ class RedisRefreshTokenServiceTest {
 
 		//then
 		assertThat(redisRefreshTokenRepository.findById(userId)).isPresent();
+	}
+
+	@Test
+	void refresh_token_갱신_성공() {
+		//given
+		final Long userId = 1L;
+		final RegisterRefreshTokenCommand oldCommand = new RegisterRefreshTokenCommand(
+			userId,
+			"oldRefreshToken",
+			10000L);
+		refreshTokenService.registerRefreshToken(oldCommand);
+
+		final String newRefreshToken = "newRefreshToken";
+		final RegisterRefreshTokenCommand newCommand = new RegisterRefreshTokenCommand(userId, newRefreshToken, 1000L);
+
+		//when
+		refreshTokenService.registerRefreshToken(newCommand);
+
+		//then
+		final RefreshToken token = redisRefreshTokenRepository.findById(userId).get();
+		assertAll(
+			() -> assertThat(token).isNotNull(),
+			() -> assertThat(token.getValue()).isEqualTo(newRefreshToken)
+		);
+	}
+
+	@Test
+	void refresh_token_검증_성공() {
+		//given
+		final Long userId = 1L;
+		final String refreshToken = "refreshToken";
+		final RegisterRefreshTokenCommand command = new RegisterRefreshTokenCommand(userId, refreshToken, 10000L);
+
+		refreshTokenService.registerRefreshToken(command);
+
+		//when then
+		assertDoesNotThrow(() -> refreshTokenService.validateRefreshToken(userId, refreshToken));
+	}
+
+	@Test
+	void refresh_token_검증_실패_옛날_refresh_token() {
+		//given
+		final Long userId = 1L;
+		final String oldRefreshToken = "oldRefreshToken";
+		final RegisterRefreshTokenCommand oldCommand = new RegisterRefreshTokenCommand(userId, oldRefreshToken, 1000L);
+		refreshTokenService.registerRefreshToken(oldCommand);
+
+		final RegisterRefreshTokenCommand newCommand = new RegisterRefreshTokenCommand(userId, "refreshToken", 1000L);
+		refreshTokenService.registerRefreshToken(newCommand);
+
+		//when then
+		assertThatExceptionOfType(JwtException.class).isThrownBy(
+			() -> refreshTokenService.validateRefreshToken(userId, oldRefreshToken));
+	}
+
+	@Test
+	void refresh_token_삭제_성공() {
+		//given
+		final Long userId = 1L;
+		final RegisterRefreshTokenCommand command = new RegisterRefreshTokenCommand(userId, "refreshToken", 1000L);
+		refreshTokenService.registerRefreshToken(command);
+
+		//when
+		refreshTokenService.removeRefreshToken(userId);
+
+		//then
+		assertThat(redisRefreshTokenRepository.findById(userId)).isEmpty();
 	}
 }

--- a/src/test/java/com/meoguri/linkocean/test/restdocs/AuthRestDocsTest.java
+++ b/src/test/java/com/meoguri/linkocean/test/restdocs/AuthRestDocsTest.java
@@ -1,28 +1,27 @@
 package com.meoguri.linkocean.test.restdocs;
 
+import static com.meoguri.linkocean.internal.user.domain.model.OAuthType.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.*;
 import static org.springframework.http.MediaType.*;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.restdocs.request.RequestDocumentation.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
 
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.web.servlet.ResultActions;
 
 import com.meoguri.linkocean.controller.user.AuthController;
 import com.meoguri.linkocean.controller.user.dto.AuthRequest;
-import com.meoguri.linkocean.internal.user.application.OAuthClient;
+import com.meoguri.linkocean.controller.user.dto.AuthResponse;
+import com.meoguri.linkocean.controller.user.dto.RefreshAccessTokenRequest;
 import com.meoguri.linkocean.internal.user.domain.model.Email;
 import com.meoguri.linkocean.test.restdocs.support.RestDocsTestSupport;
 
 class AuthRestDocsTest extends RestDocsTestSupport {
 
 	private final String basePath = getBaseUrl(AuthController.class);
-
-	@MockBean
-	private OAuthClient oAuthClient;
 
 	@Test
 	void 사용자_인증_api() throws Exception {
@@ -48,6 +47,38 @@ class AuthRestDocsTest extends RestDocsTestSupport {
 					requestFields(
 						fieldWithPath("code").description("인증 코드"),
 						fieldWithPath("redirectUri").description("REDIRECT URI")
+					),
+					responseFields(
+						fieldWithPath("accessToken").description("리소스 접근 전용 토큰"),
+						fieldWithPath("refreshToken").description("access token 재발급 용도의 토큰"),
+						fieldWithPath("tokenType").description("토큰 타입")
+					)
+				)
+			);
+	}
+
+	@Test
+	void access_token_재발급_api() throws Exception {
+		//given
+		final AuthResponse authResponse = 로그인(GOOGLE, "code", "http://localhost/redirect");
+
+		final RefreshAccessTokenRequest request = new RefreshAccessTokenRequest(
+			authResponse.getRefreshToken(),
+			authResponse.getTokenType());
+
+		//when
+		final ResultActions perform = mockMvc.perform(post(basePath + "/token/refresh")
+			.contentType(APPLICATION_JSON)
+			.content(createJson(request))
+			.accept(APPLICATION_JSON));
+
+		//then
+		perform
+			.andDo(
+				restDocs.document(
+					requestFields(
+						fieldWithPath("refreshToken").description("재발급 토큰"),
+						fieldWithPath("tokenType").description("토큰 타입")
 					),
 					responseFields(
 						fieldWithPath("accessToken").description("리소스 접근 전용 토큰"),

--- a/src/test/java/com/meoguri/linkocean/test/support/controller/BaseControllerTest.java
+++ b/src/test/java/com/meoguri/linkocean/test/support/controller/BaseControllerTest.java
@@ -99,7 +99,7 @@ public abstract class BaseControllerTest {
 		final String code,
 		final String redirectUri
 	) throws Exception {
-		given(oAuthClient.getUserEmail(any())).willReturn(new Email("email@google.com"));
+		given(oAuthClient.getUserEmail(any())).willReturn(new Email("email@gmail.com"));
 
 		final MvcResult mvcResult = mockMvc.perform(post("/api/v1/auth/{oAuthType}", oAuthType)
 				.contentType(APPLICATION_JSON)

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -22,4 +22,5 @@ spring:
 
 jwt:
   secret-key: test
-  expiration: 3600000
+  access-token-expiration: 3600000
+  refresh-token-expiration: 3600000


### PR DESCRIPTION
<!-- PR 제목 양식 예시: [LO-N] 회원 기능 도메인 -->

## 🛠️ 작업 내용
- access token 재발급 API 개발

## 🗨️ 기타
<!-- PR 포인트 혹은 궁금한 점 등등 적어주시면 됩니다. 없으시면 지워주세요 -->
- access token의 만료일은 10시간, refresh token의 만료일은 7일로 설정했습니다.
  - refresh token의 유효기간이 길어 탈취 위험성이 있기 때문에 refresh token rotation, refresh token automatic reuse detection을 적용했습니다. ([참조](https://auth0.com/blog/refresh-tokens-what-are-they-and-when-to-use-them/#Refresh-Token-Automatic-Reuse-Detection))
- 기존에는 Jwt 파싱 과정에서 예외가 발생하면 LinkoceanRuntimeException으로 처리했는데, 이를 JwtException으로 바꾸고 핸들러에서 따로 처리하도록 개발했습니다. 이제는 401 상태를 반환합니다. 
- Test 관련해서는 Service 테스트에서는 OAuthClient, RefreshTokenService 컴포넌트는 외부 컨포넌트라고 가정하고 모킹했습니다. 하지만 Controller 테스트에서는 Redis는 직접 사용했습니다. 완전 통합 테스트라 가정해 프로덕션 환경과 맞출 수 있는 부분은 최대한 맞췄습니다. (OAuthClient는 Jsoup과 동일하게 네트워크 통신이 필요한 API이기 때문에 완전 통합 테스트에서도 모킹했습니다.)

## 😎 리뷰어
@ndy2 